### PR TITLE
improved markdown for tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .DS_Store
 .git-hooks/
 .vscode/
+.idea/
 .task/
 .latestcheck
 .test_fail_then_succeed

--- a/tools/base64.md
+++ b/tools/base64.md
@@ -1,14 +1,36 @@
-# Tool `-base64`
+# Tool base64
+
+base64 utility acts as a base64 decoder when passed the --decode (or -d) flag and as a base64 encoder
+otherwise.  As a decoder it only accepts raw base64 input and as an encoder it does not produce the framing
+lines.  base64 reads standard input or file if it is provided and writes to standard output.  Options
+--wrap (or -w) and --ignore-garbage (or -i) are accepted for compatibility with GNU base64, but the latter
+is unimplemented and silently ignored.
 
 ```text
 Usage:
   ops -base64 [options] <string>
 ```
 
-# Options
+## Options
 
 ```
   -h, --help             Display this help message
   -e, --encode <string>  Encode a string to base64
   -d, --decode <string>  Decode a base64 string
+```
+
+## Examples
+
+### Encoding: 
+
+```bash
+ops -base64 -e "OpenServerless is wonderful"
+T3BlblNlcnZlcmxlc3MgaXMgd29uZGVyZnVs
+```
+
+### Decoding: 
+
+```bash
+$ ops -base64 -d "T3BlblNlcnZlcmxlc3MgaXMgd29uZGVyZnVs"
+OpenServerless is wonderful
 ```

--- a/tools/datefmt.md
+++ b/tools/datefmt.md
@@ -7,7 +7,7 @@ Usage:
   ops -datefmt [options] [arguments]
 ```
 
-# Options
+## Options
 
 ```
     -h, --help		 print this help info
@@ -40,3 +40,10 @@ Possible formats (they follows the standard naming of go time formats, with the 
 - TimeOnly
 - Milliseconds
 - ms
+
+## Example
+
+```bash
+$ ops -datefmt -f DateTime
+2024-08-11 03:00:34
+```


### PR DESCRIPTION
Hello,
i improved a bit the markdown for the first two documented tools inside the cli: base64 and datefmt.

I think that these can be used as a template for the other tools.

A rendered example inside the openserverless-site is here: https://openserverless-demo.netlify.app/docs/reference/tools/