### PR TITLE
Refactor the tool help system inside the cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -341,7 +341,7 @@ func Main() {
 	}
 
 	// setup the envvar for the embedded tools
-	os.Setenv("OPS_TOOLS", strings.Join(append(mainTools, tools.ToolList...), " "))
+	os.Setenv("OPS_TOOLS", strings.Join(tools.MergeToolsList(mainTools), " "))
 
 	// CLI: ops -v | --version | -h | --help | -reset
 	// preliminanre processing not requiring to  downloading anything

--- a/prepare_test.go
+++ b/prepare_test.go
@@ -58,7 +58,6 @@ func Example_download() {
 	// Updating tasks...
 	// Tasks are already up to date!
 	// 2 <nil> /home/.ops/0.1.0/olaris
-
 }
 
 func Example_locate_root() {

--- a/tests/datefmt.bats
+++ b/tests/datefmt.bats
@@ -21,15 +21,16 @@ setup() {
     export NO_COLOR=1
 }
 
-@test "datefmt print usage" {
+@test "-datefmt help message" {
     run ops -datefmt -h
     assert_success
-    assert_line "Usage:"
+    assert_line --partial "ops -datefmt [options] [arguments]"
 
     run ops -datefmt --help
     assert_success
-    assert_line "Usage:"
+    assert_line --partial "ops -datefmt [options] [arguments]"
 }
+
 
 @test "datefmt with input timestamp and output format" {
     run ops -datefmt -t 1577836800 -f DateOnly

--- a/tests/echoif.bats
+++ b/tests/echoif.bats
@@ -23,10 +23,12 @@ setup() {
 
 @test "-echoif help message" {
     run ops -echoif
-    assert_line "Usage: echoif <a> <b>"
+    assert_success
+    assert_line --partial "ops -echoif <a> <b>"
 
     run ops -echoif -h
-    assert_line "Usage: echoif <a> <b>"
+    assert_success
+    assert_line --partial "ops -echoif <a> <b>"
 }
 
 @test "-echoif echoes a with successful previous command" {
@@ -43,10 +45,12 @@ setup() {
 
 @test "-echoifempty help message" {
     run ops -echoifempty
-    assert_line "Usage: echoifempty <str> <a> <b>"
+    assert_success
+    assert_line --partial "ops -echoifempty <str> <a> <b>"
 
     run ops -echoifempty -h
-    assert_line "Usage: echoifempty <str> <a> <b>"
+    assert_success
+        assert_line --partial "ops -echoifempty <str> <a> <b>"
 }
 
 @test "-echoifempty echoes a if string is empty" {
@@ -61,10 +65,12 @@ setup() {
 
 @test "-echoifexists help message" {
     run ops -echoifexists
-    assert_line "Usage: echoifexists <file> <a> <b>"
+    assert_success
+    assert_line --partial "ops -echoifexists <file> <a> <b>"
 
     run ops -echoifexists -h
-    assert_line "Usage: echoifexists <file> <a> <b>"
+    assert_success
+    assert_line --partial "ops -echoifexists <file> <a> <b>"
 }
 
 @test "-echoifexists echoes a if file exists" {

--- a/tests/extract.bats
+++ b/tests/extract.bats
@@ -24,7 +24,8 @@ setup() {
 
 @test "extract" {
     run ops -extract
-    assert_line "Usage: file.(zip|tgz|tar[.gz|.bz2|.xz]) target"
+    assert_success
+    assert_line --partial "ops -extract file.(zip|tgz|tar[.gz|.bz2|.xz]) target"
     curl -sL -o7zip.tar.xz https://www.7-zip.org/a/7z2407-linux-x64.tar.xz 
 
     run ops -extract 7zip.tar.xz missing
@@ -54,17 +55,4 @@ setup() {
     run ops -extract coreutils.zip coreutils.exe
     assert_success
     assert test -e coreutils.exe
-}    
-
-@test "-empty" {
-    run ops -empty
-    assert_line "Usage: filename"
-    run ops -empty empty_file
-    assert test -f empty_file
-    assert_success
-    run ops -empty empty_file
-    assert_failure
-    assert_line "file already exists"
-    rm empty_file
-
 }

--- a/tests/filetype.bats
+++ b/tests/filetype.bats
@@ -23,10 +23,12 @@ setup() {
 
 @test "filetype usage print" {
     run ops -filetype
-    assert_line "Usage: filetype [-h] [-e] [-m] FILE"
+    assert_success
+    assert_line --partial "ops -filetype [-h] [-e] [-m] FILE"
 
     run ops -filetype -h
-    assert_line "Usage: filetype [-h] [-e] [-m] FILE"
+    assert_success
+    assert_line --partial "ops -filetype [-h] [-e] [-m] FILE"
 }
 
 @test "filetype -e" {

--- a/tests/needupdate.bats
+++ b/tests/needupdate.bats
@@ -23,10 +23,12 @@ setup() {
 
 @test "needupdate message" {
     run ops -needupdate
-    assert_line "Usage:"
+    assert_failure
+    assert_line --partial "ops -needupdate <versionA> <versionB>"
 
     run ops -needupdate -h
-    assert_line "Usage:"
+    assert_success
+    assert_line --partial "ops -needupdate <versionA> <versionB>"
 }
 
 @test "needupdate returns 0 if a > b" {

--- a/tests/random.bats
+++ b/tests/random.bats
@@ -24,11 +24,11 @@ setup() {
 @test "ops -random help" {
     run ops -random -h
     assert_success
-    assert_line "Usage:"
+    assert_line --partial "ops -random [options]"
 
     run ops -random --help
     assert_success
-    assert_line "Usage:"
+    assert_line --partial "ops -random [options]"
 }
 
 @test "ops -random" {

--- a/tests/retry.bats
+++ b/tests/retry.bats
@@ -24,15 +24,15 @@ setup() {
 @test "ops -retry help" {
     run ops -retry
     assert_success
-    assert_line "Usage:"
+    assert_line --partial "ops -retry [options] task [task options]"
 
     run ops -retry -h
     assert_success
-    assert_line "Usage:"
+    assert_line --partial "ops -retry [options] task [task options]"
 
     run ops -retry --help
     assert_success
-    assert_line "Usage:"
+    assert_line --partial "ops -retry [options] task [task options]"
 }
 
 @test "ops -retry fail" {

--- a/tests/urlenc.bats
+++ b/tests/urlenc.bats
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+    export NO_COLOR=1
+}
+
+@test "ops -urlenc help" {
+    run ops -urlenc -h
+    assert_success
+    assert_line --partial "ops -urlenc [-e] [-s <string>] [parameters]"
+
+    run ops -urlenc --help
+    assert_success
+    assert_line --partial "ops -urlenc [-e] [-s <string>] [parameters]"
+}
+
+@test "ops -urlenc" {
+  run ops -urlenc
+  assert_success
+  refute_output
+
+  run ops -urlenc a=1 b=2
+  assert_success
+  assert_line "a%3D1&b%3D2"
+
+  run ops -urlenc -s "|" a=1 b=2
+  assert_success
+  assert_line "a%3D1|b%3D2"
+}
+
+@test "ops -urlenc string from env" {
+  run env TEST=ops ops -urlenc -e TEST
+  assert_line "ops"
+}

--- a/tests/utils.bats
+++ b/tests/utils.bats
@@ -24,14 +24,15 @@ setup() {
 
 @test "-rename -remove" {
     run ops -rename
-    assert_line "Usage: rename <source> <destination>"
+    assert_success
+    assert_line --partial "ops -rename <source> <destination>"
 
-    run ops -rename missing 
-    assert_line "Usage: rename <source> <destination>"
+    run ops -rename missing
+    assert_success
+    assert_line --partial "ops -rename <source> <destination>"
 
     run ops -rename missing something
-    assert_failure
-    assert_line "rename missing something: no such file or directory" 
+    assert_line "rename missing something: no such file or directory"
 
     touch something
     run ops -rename something somethingelse
@@ -40,10 +41,17 @@ setup() {
 
     run ops -rename somethingelse /dev/null
     assert_failure
-    assert_line "rename somethingelse /dev/null: invalid cross-device link"
+    case $OSTYPE in
+      darwin*)
+        assert_line "rename somethingelse /dev/null: cross-device link"
+        ;;
+      *)
+        assert_line "rename somethingelse /dev/null: invalid cross-device link"
+    esac
 
     run ops -remove
-    assert_line "Usage: remove <filename>"
+    assert_success
+    assert_line --partial "ops -remove <filename>"
 
     run ops -remove missing
     assert_failure
@@ -56,7 +64,8 @@ setup() {
 
 @test "-empty" {
     run ops -empty
-    assert_line "Usage: filename"
+    assert_success
+    assert_line --partial "ops -empty <filename>"
     run ops -empty empty_file
     assert test -f empty_file
     assert_success
@@ -67,6 +76,9 @@ setup() {
 }
 
 @test "-executable"  {
+    run ops -executable
+    assert_success
+    assert_line --partial "ops -executable <filename>"
     touch _hello
     chmod 0600 _hello
     run env __OS=linux ops -executable _hello

--- a/tests/validate.bats
+++ b/tests/validate.bats
@@ -23,11 +23,13 @@ setup() {
 
 @test "ops validate help" {
     run ops -validate
-    assert_line "Usage:"
+    assert_failure
+    assert_line --partial "ops -validate [-e] [-m | -n | -r <regex>] <value> [<message>]"
+    assert_line "invalid number of arguments"
 
     run ops -validate -h
-    assert_line "Usage:"
-    assert_line "ops -validate [-e] [-m | -n | -r <regex>] <value> [<message>]"
+    assert_success
+    assert_line --partial "ops -validate [-e] [-m | -n | -r <regex>] <value> [<message>]"
 }
 
 @test "ops validate email" {

--- a/tools/base64.go
+++ b/tools/base64.go
@@ -24,9 +24,6 @@ import (
 	"fmt"
 )
 
-//go:embed base64.md
-var base64usage string
-
 func base64Tool() error {
 
 	var (
@@ -36,7 +33,7 @@ func base64Tool() error {
 	)
 
 	flag.Usage = func() {
-		fmt.Println(MarkdownToText(base64usage))
+		fmt.Println(MarkdownHelp("base64"))
 	}
 
 	flag.BoolVar(&helpFlag, "h", false, "Display this help message")

--- a/tools/base64.md
+++ b/tools/base64.md
@@ -1,11 +1,6 @@
-
-# Tool base64
-
-base64 utility acts as a base64 decoder when passed the --decode (or -d) flag and as a base64 encoder
-otherwise.  As a decoder it only accepts raw base64 input and as an encoder it does not produce the framing
-lines.  base64 reads standard input or file if it is provided and writes to standard output.  Options
---wrap (or -w) and --ignore-garbage (or -i) are accepted for compatibility with GNU base64, but the latter
-is unimplemented and silently ignored.
+`base64` utility acts as a base64 decoder when passed the `--decode` (or -d) flag and as a base64 encoder
+otherwise. As a decoder it only accepts raw base64 input and as an encoder it does not produce the framing
+lines.
 
 ```text
 Usage:
@@ -22,16 +17,26 @@ Usage:
 
 ## Examples
 
-### Encoding: 
+### Encoding
 
 ```bash
 ops -base64 -e "OpenServerless is wonderful"
+```
+
+This will output:
+
+```text
 T3BlblNlcnZlcmxlc3MgaXMgd29uZGVyZnVs
 ```
 
-### Decoding: 
+### Decoding
 
 ```bash
-$ ops -base64 -d "T3BlblNlcnZlcmxlc3MgaXMgd29uZGVyZnVs"
+ops -base64 -d "T3BlblNlcnZlcmxlc3MgaXMgd29uZGVyZnVs"
+```
+
+This will output:
+
+```text
 OpenServerless is wonderful
 ```

--- a/tools/base64.md
+++ b/tools/base64.md
@@ -10,9 +10,9 @@ Usage:
 ## Options
 
 ```
-  -h, --help             Display this help message
-  -e, --encode <string>  Encode a string to base64
-  -d, --decode <string>  Decode a base64 string
+-h, --help             Display this help message
+-e, --encode <string>  Encode a string to base64
+-d, --decode <string>  Decode a base64 string
 ```
 
 ## Examples

--- a/tools/datefmt.go
+++ b/tools/datefmt.go
@@ -25,9 +25,6 @@ import (
 	"time"
 )
 
-//go:embed datefmt.md
-var datefmtUsage string
-
 // if you change this add it to the datefmt.md
 var dateFormats = map[string]string{
 	"Layout":      time.Layout,
@@ -66,6 +63,10 @@ var (
 func DateFmtTool(args []string) error {
 	os.Args = args
 
+	flag.Usage = func() {
+		fmt.Println(MarkdownHelp("datefmt"))
+	}
+
 	flag.BoolVar(&helpFlag, "h", false, "print this help info")
 	flag.BoolVar(&helpFlag, "help", false, "print this help info")
 	flag.Int64Var(&timestampFlag, "t", time.Now().Unix(), "unix timestamp to convert")
@@ -79,7 +80,7 @@ func DateFmtTool(args []string) error {
 	flag.Parse()
 
 	if helpFlag {
-		fmt.Println(MarkdownToText(datefmtUsage))
+		flag.Usage()
 		return nil
 	}
 

--- a/tools/datefmt.md
+++ b/tools/datefmt.md
@@ -8,11 +8,11 @@ Usage:
 ## Options
 
 ```
-    -h, --help		 print this help info
-    -t, --timestamp	 unix timestamp to format (default: current time)
-    -s, --str 	  	 date string to format
-    --if			 input format to use with input date string (via --str)
-    -f, --of		 output format to use (default: UnixDate)
+-h, --help		 print this help info
+-t, --timestamp	 unix timestamp to format (default: current time)
+-s, --str 	  	 date string to format
+--if			 input format to use with input date string (via --str)
+-f, --of		 output format to use (default: UnixDate)
 ```
 
 Possible formats (they follows the standard naming of go time formats, with the addition of 'Millisecond' and 'ms'):

--- a/tools/echo.go
+++ b/tools/echo.go
@@ -128,20 +128,13 @@ func echoIfExistsTool() error {
 }
 
 func printEchoIfUsage() {
-	fmt.Println(`Usage: echoif <a> <b>
-
-echoif is a utility that echoes the value of <a> if the exit code of the previous command is 0, 
-echoes the value of <b> otherwise`)
+	fmt.Println(MarkdownHelp("echoif"))
 }
 
 func printEchoIfEmptyUsage() {
-	fmt.Println(`Usage: echoifempty <str> <a> <b>
-
-echoifempty is a utility that echoes the value of <a> if <str> is empty, echoes the value of <b> otherwise`)
+	fmt.Println(MarkdownHelp("echoifempty"))
 }
 
 func printEchoIfExistsUsage() {
-	fmt.Println(`Usage: echoifexists <file> <a> <b>
-
-echoifexists is a utility that echoes the value of <a> if <file> exists, echoes the value of <b> otherwise`)
+	fmt.Println(MarkdownHelp("echoifexists"))
 }

--- a/tools/echoif.md
+++ b/tools/echoif.md
@@ -1,0 +1,20 @@
+`echoif` is a utility that echoes the value of `<a>` if the exit code of the previous command is 0,
+echoes the value of `<b>` otherwise
+
+```text
+Usage:
+    ops -echoif <a> <b>
+```
+
+## Example
+```bash
+  $( exit 1 ); ops -echoif "0" "1"
+  1
+```
+
+or
+
+```bash
+  $( exit 0 ); ops -echoif "0" "1"
+  0
+```

--- a/tools/echoifempty.md
+++ b/tools/echoifempty.md
@@ -1,0 +1,12 @@
+`echoifempty` is a utility that echoes the value of `<a>` if `<str>` is empty, echoes the value of `<b>` otherwise.
+
+```text
+Usage:
+    ops -echoifempty <str> <a> <b>
+```
+
+## Example
+
+```bash
+  ops -echoifempty "not empty string" "string is empty" "string is not empty"
+```

--- a/tools/echoifexists.md
+++ b/tools/echoifexists.md
@@ -1,0 +1,12 @@
+echoifexists is a utility that echoes the value of `<a>` if `<file>` exists, echoes the value of `<b>` otherwise.
+
+```text
+Usage:
+    ops -echoifexists <file> <a> <b>
+```
+
+## Example
+
+```bash
+  ops -echoifexists "exists" "doesn't exists"
+```

--- a/tools/empty.go
+++ b/tools/empty.go
@@ -24,7 +24,7 @@ import (
 
 func Empty() (int, error) {
 	if len(os.Args) < 2 {
-		fmt.Println("Empty creates an empty file - returns error if it already exists\nUsage: filename")
+		fmt.Println(MarkdownHelp("empty"))
 		return 0, nil
 	}
 	filename := os.Args[1]

--- a/tools/empty.md
+++ b/tools/empty.md
@@ -4,9 +4,3 @@
 Usage:
     ops -empty <filename>
 ```
-
-## Options
-
-```
--h, --help             Display this help message
-```

--- a/tools/empty.md
+++ b/tools/empty.md
@@ -1,0 +1,12 @@
+`empty` creates an empty file - returns error if it already exists.
+
+```text
+Usage:
+    ops -empty <filename>
+```
+
+## Options
+
+```
+-h, --help             Display this help message
+```

--- a/tools/executable.go
+++ b/tools/executable.go
@@ -9,9 +9,7 @@ import (
 func Executable() (int, error) {
 	args := os.Args[1:]
 	if len(args) != 1 {
-		fmt.Println("Make a file executable:")
-		fmt.Println(" chmod +x in Unix, rename to .exe in Windows")
-		fmt.Println("Usage: executable <file>")
+		fmt.Println(MarkdownHelp("executable"))
 		return 0, nil
 	}
 

--- a/tools/executable.md
+++ b/tools/executable.md
@@ -1,0 +1,12 @@
+`executable` make a file executable: on Unix-like systems it will do a chmod u+x.
+On Windows systems it will rename the file to .exe if needed.
+
+```text
+Usage:
+    ops -executable <filename>
+```
+## Example
+
+```bash
+ops -executable kind
+```

--- a/tools/extract.go
+++ b/tools/extract.go
@@ -150,8 +150,7 @@ func ExtractFileFromZip(filename string, target string) error {
 
 func Extract() (int, error) {
 	if len(os.Args) < 3 {
-		fmt.Println("Extract one single file from a .zip .tar, .tgz, .tar.gz, tar.bz2, tar.gz")
-		fmt.Println("Usage: file.(zip|tgz|tar[.gz|.bz2|.xz]) target")
+		fmt.Println(MarkdownHelp("extract"))
 		return 0, nil
 	}
 	_, err := os.Stat(os.Args[1])

--- a/tools/extract.md
+++ b/tools/extract.md
@@ -1,0 +1,14 @@
+Extract one single file from a .zip .tar, .tgz, .tar.gz, tar.bz2, tar.gz.
+
+```text
+Usage:
+    ops -extract file.(zip|tgz|tar[.gz|.bz2|.xz]) target
+```
+
+## Example
+
+Extract file named `single.pdf` from `archive.zip` archive.
+
+```bash
+ops -extract archive.zip single.pdf
+```

--- a/tools/filetype.go
+++ b/tools/filetype.go
@@ -90,9 +90,5 @@ func Filetype() error {
 }
 
 func printFiletypeHelp() {
-	fmt.Println("Usage: filetype [-h] [-e] [-m] FILE")
-	fmt.Println("Show extensione and MIME type of a file.")
-	fmt.Println(" -h  shows this help")
-	fmt.Println(" -e  show file standard extension")
-	fmt.Println(" -m  show file mime type")
+	fmt.Println(MarkdownHelp("filetype"))
 }

--- a/tools/filetype.md
+++ b/tools/filetype.md
@@ -1,0 +1,27 @@
+Show extension and MIME type of a file.
+Supported types are documented [here](https://github.com/h2non/filetype?tab=readme-ov-file#supported-types)
+
+```text
+Usage:
+    ops -filetype [-h] [-e] [-m] FILE
+```
+
+## Options
+
+```
+-h  shows this help
+-e  show file standard extension
+-m  show file mime type
+```
+
+## Examples
+
+### File Mime type
+
+```bash
+ops -filetype -m `which ops`
+```
+
+This will output the ops executable type:
+``application/x-mach-binary`` or `application/x-executable`
+

--- a/tools/needupdate.go
+++ b/tools/needupdate.go
@@ -28,14 +28,7 @@ func needUpdateTool(args []string) error {
 
 	flag := flag.NewFlagSet("needupdate", flag.ExitOnError)
 	flag.Usage = func() {
-		fmt.Println(`Check if a semver version A > semver version B.
-Exits with 0 if greater, 1 otherwise.
-
-Usage:
-  ops -needupdate <versionA> <versionB>
-  
-Options:`)
-		flag.PrintDefaults()
+		fmt.Println(MarkdownHelp("needupdate"))
 	}
 
 	helpFlag := flag.Bool("help", false, "Print this help")

--- a/tools/needupdate.md
+++ b/tools/needupdate.md
@@ -9,7 +9,7 @@ Usage:
 ## Options
 
 ```
-    -h, --help		 print this help info
+-h, --help		 print this help info
 ```
 
 ## Examples

--- a/tools/needupdate.md
+++ b/tools/needupdate.md
@@ -1,0 +1,39 @@
+Check if a semver version A > semver version B.
+Exits with 0 if greater, 1 otherwise.
+
+```text
+Usage:
+    ops -needupdate <versionA> <versionB>
+```
+
+## Options
+
+```
+    -h, --help		 print this help info
+```
+
+## Examples
+
+### Update is needed
+
+```bash
+ops -needupdate 1.0.1 1.0.0; echo $?
+```
+
+This will output:
+
+```text
+0
+```
+
+### Update is not needed
+
+```bash
+ops -needupdate 1.0.0 1.0.1; echo $?
+```
+
+This will output:
+
+```text
+1
+```

--- a/tools/random.go
+++ b/tools/random.go
@@ -80,16 +80,7 @@ func RandTool(args ...string) error {
 	flag := flag.NewFlagSet("random", flag.ExitOnError)
 
 	flag.Usage = func() {
-		fmt.Println(`Generate random numbers, strings and uuids
-		
-Usage:
-	ops -random [options]
-
-Options:
-	-h, --help  shows this help
-	-u, --uuid  generates a random uuid v4
-	--int  <max> [min] generates a random non-negative integer between min and max (default min=0)
-	--str  <len> [<characters>] generates an alphanumeric string of length <len> from the set of <characters> provided (default <characters>=a-zA-Z0-9)`)
+		fmt.Println(MarkdownHelp("random"))
 	}
 
 	var helpFlag bool

--- a/tools/random.md
+++ b/tools/random.md
@@ -1,0 +1,40 @@
+Generate random numbers, strings and uuids
+
+```text
+Usage:
+    ops -random [options]
+```
+
+## Options
+
+```
+-h, --help  shows this help
+-u, --uuid  generates a random uuid v4
+--int  <max> [min] generates a random non-negative integer between min and max (default min=0)
+--str  <len> [<characters>] generates an alphanumeric string of length <len> from the set of <characters> provided (default <characters>=a-zA-Z0-9)
+```
+ 
+## Examples
+
+### Random uuid v4:
+
+```bash
+ops -random -u                 
+```
+
+This will output something like:
+
+```text
+5b2c45ef-7d15-4a15-84c6-29144393b621
+```
+
+### Random integer between max and min
+```bash
+ops -random --int 100 60
+```
+
+This will output something like:
+
+```text
+78
+```

--- a/tools/remove.go
+++ b/tools/remove.go
@@ -24,7 +24,7 @@ import (
 
 func Remove() (int, error) {
 	if len(os.Args) != 2 {
-		fmt.Println("Remove a file\nUsage: remove <filename>")
+		fmt.Println(MarkdownHelp("remove"))
 		return 0, nil
 	}
 

--- a/tools/remove.md
+++ b/tools/remove.md
@@ -1,0 +1,7 @@
+Remove a file
+
+```text
+Usage:
+    ops -remove <filename>
+```
+

--- a/tools/rename.go
+++ b/tools/rename.go
@@ -24,7 +24,7 @@ import (
 
 func Rename() (int, error) {
 	if len(os.Args) != 3 {
-		fmt.Println("Rename a file\nUsage: rename <source> <destination>")
+		fmt.Println(MarkdownHelp("rename"))
 		return 0, nil
 	}
 

--- a/tools/rename.md
+++ b/tools/rename.md
@@ -1,0 +1,6 @@
+Rename a file
+
+```text
+Usage:
+    ops -rename <source> <destination>
+```

--- a/tools/render_test.go
+++ b/tools/render_test.go
@@ -1,14 +1,17 @@
 package tools
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func Example_markdown2text() {
-	fmt.Println(len(MarkdownToText(base64usage)))
-	// Output: 945
+	markdown, _ := GetMarkDown("base64")
+	fmt.Println(len(MarkdownToText(markdown)))
+	// Output: 737
 }
 
 func Example_extractUsage() {
-	fmt.Println(len(ExtractUsage(base64usage)))
+	markdown, _ := GetMarkDown("base64")
+	fmt.Println(len(ExtractUsage(markdown)))
 	// Output: 40
-
 }

--- a/tools/retry.go
+++ b/tools/retry.go
@@ -105,12 +105,5 @@ func retry(fn func([]string) error, args []string, maxTime int, maxRetries int) 
 }
 
 func printRetryHelp() {
-	fmt.Print(
-		`Usage:
-ops -retry [options] task [task options]
--h, --help	Print help message
--t, --tries=#	Set max retries: Default 10
--m, --max=secs	Maximum time to run (set to 0 to disable): Default 60 seconds
--v, --verbose	Verbose output
-`)
+	fmt.Println(MarkdownHelp("retry"))
 }

--- a/tools/retry.md
+++ b/tools/retry.md
@@ -1,0 +1,21 @@
+```text
+Usage:
+    ops -retry [options] task [task options]
+```
+
+## Options
+
+```text
+-h, --help	Print help message
+-t, --tries=#	Set max retries: Default 10
+-m, --max=secs	Maximum time to run (set to 0 to disable): Default 60 seconds
+-v, --verbose	Verbose output
+```
+
+## Example
+
+Retry two times to get the ops action list
+
+```bash
+ops -retry -t 2 ops action list
+```

--- a/tools/sh.go
+++ b/tools/sh.go
@@ -38,7 +38,7 @@ func Sh() (int, error) {
 	if len(os.Args) > 1 {
 		path = os.Args[1]
 		if path == "-h" || path == "--help" {
-			fmt.Println("Sh is the mvdan shell using the ops environment.\nUsage: [<script>|-h|--help]\nWithout args starts an interactive shell otherwise execute the script.")
+			fmt.Println(MarkdownHelp("sh"))
 			return 0, nil
 		}
 	}

--- a/tools/sh.md
+++ b/tools/sh.md
@@ -1,0 +1,11 @@
+`sh` is the mvdan shell using the ops environment.
+
+Without args, starts an interactive shell. Otherwise execute the script specified on command line.
+
+```text
+Usage: 
+    ops -sh [<script>|-h|--help]
+```
+
+
+

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -17,6 +17,7 @@
 package tools
 
 import (
+	"embed"
 	"fmt"
 	"log"
 	"os"
@@ -31,6 +32,9 @@ import (
 	"github.com/nuvolaris/jj"
 	"golang.org/x/exp/slices"
 )
+
+//go:embed *.md
+var markDownHelp embed.FS
 
 var tracing = os.Getenv("TRACE") != ""
 
@@ -57,39 +61,45 @@ func GetARCH() string {
 	return res
 }
 
+type Tool struct {
+	Name   string
+	HasDoc bool
+}
+
 // available in taskfiles
 // note some of them are implemented in main.go (config, retry)
 // Note the comment with @DOC which is used to generate the list of tools in documentation
 // put one here if you add a markdown file for a tool
-var ToolList = []string{
-	"wsk",
-	"awk",
-	"jq",
-	"sh", //@DOC
-	"envsubst",
-	"filetype", //@DOC
-	"random",   //@DOC
-	"datefmt",  //@DOC
-	"die",
-	"urlenc", //@DOC
-	"replace",
-	"base64",       //@DOC
-	"validate",     //@DOC
-	"echoif",       //@DOC
-	"echoifempty",  //@DOC
-	"echoifexists", //@DOC
-	"needupdate",   //@DOC
-	"gron", "jj",
-	"rename",     //@DOC
-	"remove",     //@DOC
-	"executable", //@DOC
-	"empty",      //@DOC
-	"extract",    //@DOC
+var ToolList = []Tool{
+	{"wsk", false},
+	{"awk", false},
+	{"jq", false},
+	{"sh", true}, // @DOC
+	{"envsubst", false},
+	{"filetype", true}, // @DOC
+	{"random", true},   // @DOC
+	{"datefmt", true},  // @DOC
+	{"die", false},
+	{"urlenc", true}, // @DOC
+	{"replace", false},
+	{"base64", true},       // @DOC
+	{"validate", true},     // @DOC
+	{"echoif", true},       // @DOC
+	{"echoifempty", true},  // @DOC
+	{"echoifexists", true}, // @DOC
+	{"needupdate", true},   // @DOC
+	{"gron", false},
+	{"jj", false},
+	{"rename", true},     // @DOC
+	{"remove", true},     // @DOC
+	{"executable", true}, // @DOC
+	{"empty", true},      // @DOC
+	{"extract", true},    // @DOC
 }
 
 func IsTool(name string) bool {
 	for _, s := range ToolList {
-		if s == name {
+		if s.Name == name {
 			return true
 		}
 	}
@@ -227,11 +237,43 @@ func RunTool(name string, args []string) (int, error) {
 	return 0, nil
 }
 
+func MergeToolsList(mainTools []string) []string {
+	availableTools := append(mainTools)
+	for _, tool := range ToolList {
+		availableTools = append(availableTools, tool.Name)
+	}
+	return availableTools
+}
+
 func Help(mainTools []string) {
 	fmt.Println("Tools (use -<tool> -h for help):")
-	availableTools := append(mainTools, ToolList...)
+	availableTools := MergeToolsList(mainTools)
 	slices.Sort(availableTools)
 	for _, x := range availableTools {
 		fmt.Printf("-%s\n", x)
 	}
+}
+
+func GetMarkDown(toolName string) (string, error) {
+	// extract markdown from embedded resource
+	markDownFile := fmt.Sprintf("%s.md", toolName)
+	fileData, err := markDownHelp.ReadFile(markDownFile)
+	if err != nil {
+		return "", err
+	}
+	return string(fileData), nil
+}
+
+func MarkdownHelp(toolName string) string {
+	// extract markdown from embedded resource
+	fileData, err := GetMarkDown(toolName)
+	if err != nil {
+		return ""
+	}
+	result := string(fileData)
+	// convert to markdown
+	help := MarkdownToText(result)
+
+	// return opts and help markdown
+	return help
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -65,26 +65,26 @@ var ToolList = []string{
 	"wsk",
 	"awk",
 	"jq",
-	"sh",
+	"sh", //@DOC
 	"envsubst",
-	"filetype",
-	"random",
-	"datefmt", //@DOC
+	"filetype", //@DOC
+	"random",   //@DOC
+	"datefmt",  //@DOC
 	"die",
-	"urlenc",
+	"urlenc", //@DOC
 	"replace",
-	"base64", //@DOC
-	"validate",
-	"echoif",
-	"echoifempty",
-	"echoifexists",
-	"needupdate",
+	"base64",       //@DOC
+	"validate",     //@DOC
+	"echoif",       //@DOC
+	"echoifempty",  //@DOC
+	"echoifexists", //@DOC
+	"needupdate",   //@DOC
 	"gron", "jj",
-	"rename",
-	"remove",
-	"executable",
-	"empty",
-	"extract",
+	"rename",     //@DOC
+	"remove",     //@DOC
+	"executable", //@DOC
+	"empty",      //@DOC
+	"extract",    //@DOC
 }
 
 func IsTool(name string) bool {

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1,0 +1,36 @@
+package tools
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMarkdownHelp(t *testing.T) {
+	for _, s := range ToolList {
+		if s.HasDoc {
+			opt := MarkdownHelp(s.Name)
+			if opt == "" {
+				t.Fatalf("Tool %s doesn't have valid help", s.Name)
+			}
+		}
+	}
+}
+
+func TestGetMarkDownSuccess(t *testing.T) {
+	t.Helper()
+	_, err := GetMarkDown("base64")
+	require.NoError(t, err)
+}
+
+func TestGetMarkDownError(t *testing.T) {
+	t.Helper()
+	_, err := GetMarkDown("notexistenttool")
+	require.Error(t, err)
+}
+
+func ExampleMergeToolsList() {
+	mergedList := MergeToolsList([]string{})
+	fmt.Println(len(mergedList))
+	//Output: 24
+}

--- a/tools/urlenc.go
+++ b/tools/urlenc.go
@@ -26,12 +26,21 @@ import (
 )
 
 func URLEncTool() error {
+	var (
+		separator string
+		encodeEnv bool
+		helpFlag  bool
+	)
+
 	// Define command-line flags
 	fs := flag.NewFlagSet("urlenc", flag.ContinueOnError)
 
-	separator := fs.String("s", "&", "Separator for concatenating the parameters")
-	encodeEnv := fs.Bool("e", false, "Encode parameter values from environment variables")
-	help := fs.Bool("h", false, "Show help")
+	fs.Usage = printUrlEncHelp
+
+	fs.StringVar(&separator, "s", "&", "Separator for concatenating the parameters")
+	fs.BoolVar(&encodeEnv, "e", false, "Encode parameter values from environment variables")
+	fs.BoolVar(&helpFlag, "help", false, "Print help message")
+	fs.BoolVar(&helpFlag, "h", false, "Print help message")
 
 	// Parse command-line flags
 	err := fs.Parse(os.Args[1:])
@@ -39,7 +48,7 @@ func URLEncTool() error {
 		return err
 	}
 
-	if *help {
+	if helpFlag {
 		fs.Usage()
 		return nil
 	}
@@ -51,14 +60,18 @@ func URLEncTool() error {
 	params := make([]string, 0)
 
 	for _, arg := range args {
-		if *encodeEnv {
+		if encodeEnv {
 			arg = os.Getenv(arg)
 		}
 		encodedValue := url.QueryEscape(arg)
 		params = append(params, encodedValue)
 	}
 
-	result := strings.Join(params, *separator)
+	result := strings.Join(params, separator)
 	fmt.Println(result)
 	return nil
+}
+
+func printUrlEncHelp() {
+	fmt.Println(MarkdownHelp("urlenc"))
 }

--- a/tools/urlenc.md
+++ b/tools/urlenc.md
@@ -1,0 +1,26 @@
+urlencode parameters using the default & separator (or a specific one using -s flag).
+Optionally, encode the values retrieving them from environment variables.
+
+```text
+Usage:
+    ops -urlenc [-e] [-s <string>] [parameters]
+```
+
+## Options
+```
+-e    Encode parameter values from environment variables
+-h    Show help
+-s string  Separator for concatenating the parameters (default "&")
+```
+
+## Examples
+
+```bash
+ops -urlenc a=1 b=2
+```
+
+This will output:
+
+```text
+a%3D1&b%3D2
+```

--- a/tools/validate.go
+++ b/tools/validate.go
@@ -29,16 +29,7 @@ import (
 func validateTool() error {
 	flag := flag.NewFlagSet("validate", flag.ContinueOnError)
 
-	flag.Usage = func() {
-		fmt.Println(`Usage:
-ops -validate [-e] [-m | -n | -r <regex>] <value> [<message>]
-
-Check if a value is valid according to the given constraints.
-If -e is specified, the value is retrieved from the environment variable with the given name.
-
-Options:`)
-		flag.PrintDefaults()
-	}
+	flag.Usage = printValidateHelp
 
 	helpFlag := flag.Bool("h", false, "Print this help message.")
 	envFlag := flag.Bool("e", false, "Retrieve value from the environment variable with the given name.")
@@ -128,4 +119,8 @@ func isValidByRegex(value string, regex string) (bool, error) {
 
 	// Use the regular expression to match the email string
 	return regExp.MatchString(value), nil
+}
+
+func printValidateHelp() {
+	fmt.Println(MarkdownHelp("validate"))
 }

--- a/tools/validate.md
+++ b/tools/validate.md
@@ -6,7 +6,7 @@ Usage:
 ops -validate [-e] [-m | -n | -r <regex>] <value> [<message>]
 ```
 
-## Options:
+## Options
 
 ```
 -e    Retrieve value from the environment variable with the given name.
@@ -15,3 +15,20 @@ ops -validate [-e] [-m | -n | -r <regex>] <value> [<message>]
 -n    Check if the value is a number.
 -r string Check if the value matches the given regular expression.
 ```
+
+## Examples
+
+### Validate with regexp
+
+### Validate email
+
+```
+ops -validate -m example@gmail.com
+```
+
+```bash
+ops -validate -r '^[a-z]+$' abc
+```
+
+
+

--- a/tools/validate.md
+++ b/tools/validate.md
@@ -1,0 +1,17 @@
+Check if a value is valid according to the given constraints.
+If -e is specified, the value is retrieved from the environment variable with the given name.
+
+```text
+Usage:
+ops -validate [-e] [-m | -n | -r <regex>] <value> [<message>]
+```
+
+## Options:
+
+```
+-e    Retrieve value from the environment variable with the given name.
+-h    Print this help message.
+-m    Check if the value is a valid email address.
+-n    Check if the value is a number.
+-r string Check if the value matches the given regular expression.
+```


### PR DESCRIPTION
Hello,
this PR resolves the issue https://github.com/apache/openserverless/issues/44.

In detail the modifications:
- added a Tool struct to add Name and an HasDoc flag (used to check which tool has markdown doc)
- added markDownHelp as embed.FS to load all markdown files from the tools folder
- added a GetMarkDown helper method to load Markdown from embed.FS starting from tool name
- added a MarkdownHelp method that will extract the Usage from markdown, using the tool name
- added a MergeToolsList helper method to handle the merge between main tools and tools
- added tests for new methods inside tools_test.go
- fixed Example_markdown2text anf Example_extractUsage tests after modifications to base64usage inside render_test.go
- modified base64 and datefmt to use new function to show the help
- modified bats test

I expect a code review before merge