### PR TITLE
Add -opspath tool

### DIFF
--- a/tests/opspath.bats
+++ b/tests/opspath.bats
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+    export NO_COLOR=1
+}
+
+@test "-opspath help message" {
+    run ops -opspath
+    assert_line "Usage:"
+
+    run ops -opspath -h
+    assert_line "Usage:"
+}
+
+@test "-opspath with relative path" {
+    WD=$(pwd)
+    run ops -opspath ./test
+    assert_success
+    assert_output "${WD}/test"
+}
+
+@test "-opspath with absolute path" {
+    WD=$(pwd)
+    run ops -opspath "${WD}/test"
+    assert_success
+    assert_output "${WD}/test"
+
+    run ops -opspath "${WD}/./test"
+    assert_success
+    assert_output "${WD}/test"
+}

--- a/tools/opspath.go
+++ b/tools/opspath.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+func OpsPath() (int, error) {
+	flags := flag.NewFlagSet("opspath", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Println(MarkdownHelp("opspath"))
+	}
+
+	showHelp := flags.Bool("h", false, "Show help")
+
+	// Parse command-line arguments
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		return 1, err
+	}
+
+	if *showHelp {
+		flags.Usage()
+		return 0, nil
+	}
+
+	if flags.NArg() != 1 {
+		flags.Usage()
+		return 1, errors.New("error: no path provided")
+	}
+
+	inputPath := filepath.Clean(filepath.FromSlash(flags.Arg(0))) // ensure correct OS separator
+
+	if filepath.IsAbs(inputPath) {
+		fmt.Println(inputPath)
+		return 0, nil
+	}
+
+	expandedPath, err := homedir.Expand(inputPath)
+	if err != nil {
+		return 1, err
+	}
+
+	if filepath.IsAbs(expandedPath) {
+		fmt.Println(expandedPath)
+		return 0, nil
+	}
+
+	fullPath, err := filepath.Abs(filepath.Join(os.Getenv("OPS_PWD"), expandedPath))
+	if err != nil {
+		return 1, err
+	}
+
+	fmt.Println(fullPath)
+
+	return 0, nil
+}

--- a/tools/opspath.md
+++ b/tools/opspath.md
@@ -1,0 +1,27 @@
+Join a relative path to the path from where `ops` was executed.
+This command is useful when creating custom tasks ( e.g. an ops plugin).
+
+```text
+Usage:
+    ops -opspath <path>
+```
+
+Options:
+
+```
+-h, --help  print this help info
+```
+
+## Examples
+
+### You are executing in directory `/home/user/my/custom/dir`
+
+```bash
+ops -opspath my-file.txt
+```
+
+This will output:
+
+```text
+/home/user/my/custom/dir/my-file.txt
+```

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -95,6 +95,7 @@ var ToolList = []Tool{
 	{"executable", true}, // @DOC
 	{"empty", true},      // @DOC
 	{"extract", true},    // @DOC
+	{"opspath", true},    // @DOC
 }
 
 func IsTool(name string) bool {
@@ -230,6 +231,9 @@ func RunTool(name string, args []string) (int, error) {
 	case "empty":
 		os.Args = append([]string{"empty"}, args...)
 		return Empty()
+	case "opspath":
+		os.Args = append([]string{"opspath"}, args...)
+		return OpsPath()
 
 	default:
 		return 1, fmt.Errorf("unknown tool")
@@ -238,7 +242,7 @@ func RunTool(name string, args []string) (int, error) {
 }
 
 func MergeToolsList(mainTools []string) []string {
-	availableTools := append(mainTools)
+	availableTools := mainTools
 	for _, tool := range ToolList {
 		availableTools = append(availableTools, tool.Name)
 	}


### PR DESCRIPTION
This PR adds a new tool `ops -opspath <path>` which will join the input path (if relative) to $OPS_PWD. 

This tool can be used in tasks to get the full path of an input file/directory from the location `ops` was executed in. 

It is needed when the tasks are located somewhere else (e.g. ~/.ops). In those cases input files would not be found since the tasks would search for the path from ~/.ops, instead of the `ops` exec location.