### PR TITLE
fix(cli): improve plugin hint (#88) and operator update guard (#41

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -257,7 +257,7 @@ func newPlugins() (*plugins, error) {
 func (p *plugins) print() {
 	if len(p.local) == 0 && len(p.ops) == 0 {
 		debug("No plugins installed")
-		fmt.Println("No plugins installed. Use 'ops -plugin' to add new ones.")
+		fmt.Println("No plugins installed. Use ops -plugin <repo_url> to install one.")
 		return
 	}
 

--- a/prepare.go
+++ b/prepare.go
@@ -223,6 +223,18 @@ func autoCLIUpdate() error {
 
 func checkOperatorVersion(opsRootConfig map[string]interface{}) error {
 	trace("checkOperatorVersion")
+	// --- NEW: Check for active operator installation ---
+	// Execute "ops debug operator:version" to see if an operator is currently deployed.
+	debugCmd := exec.Command(os.Getenv("OPS_CMD"), "debug", "operator:version")
+	output, err := debugCmd.Output()
+	if err != nil || strings.TrimSpace(string(output)) == "" {
+		// No operator installed or command failed, so suppress the update suggestion.
+		debug("No active operator installation detected or command failed:", err, "output:", strings.TrimSpace(string(output)))
+		return fmt.Errorf("no active operator installation detected") // Return an error to prevent printing the update message
+	}
+	debug("Active operator version detected:", strings.TrimSpace(string(output)))
+	// --- END NEW ---
+
 	images := opsRootConfig["images"].(map[string]interface{})
 	operator := images["operator"].(string)
 	opVer := strings.Split(operator, ":")[1]


### PR DESCRIPTION
This PR addresses two user experience issues in the CLI:

1. **Plugin Discovery (#88):** Added a usage hint with the repository URL when no plugins are found. This prevents new users from reaching a "dead end."
2. **Operator Guard (#41):** Added a check to ensure the CLI only suggests operator updates if an operator is actually installed, preventing confusing "ghost" update notifications.

### Fixes
- Fixes #41
- Fixes #88