### PR TITLE
Pin GoReleaser action revision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
              ops -version
              task tests
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
## What changed

Pins goreleaser/goreleaser-action v6 to its full commit SHA.

## Why

The release workflow terminated with startup_failure before creating any jobs. Apache GitHub Actions policy requires external actions to use an immutable full-length commit SHA.

## Impact

Release workflows can start while retaining GoReleaser v6 behavior.

## Validation

- YAML syntax parsed successfully
- git diff --check passed
- Referenced GoReleaser commit verified through GitHub