### PR TITLE
Use Apache-approved GoReleaser action revision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
              ops -version
              task tests
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
## What changed

Updates goreleaser/goreleaser-action to the immutable v7.2.3 commit SHA approved by Apache infrastructure.

## Why

The previous full SHA was valid upstream but absent from the Apache Actions allow-list, causing the release workflow to terminate with startup_failure before creating any jobs.

## Impact

The release workflow can pass Apache action-policy validation while continuing to install the configured GoReleaser v2 binary.

## Validation

- SHA confirmed in apache/infrastructure-actions approved_patterns.yml
- YAML syntax parsed successfully
- git diff --check passed