### PR TITLE
Fix dependency license configuration

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -51,5 +51,16 @@ header:
 dependency:
   files:
     - go.mod
-    - package.json 
-
+  licenses:
+    - name: github.com/xi2/xz
+      version: v0.0.0-20171230120015-48954b6210f8
+      license: Unlicense
+    - name: github.com/fatih/color
+      version: v1.17.0
+      license: MIT
+    - name: github.com/go-task/template
+      version: v0.0.0-20240602015157-960e6f576656
+      license: BSD-3-Clause
+    - name: github.com/olekukonko/tablewriter
+      version: v0.0.5
+      license: MIT


### PR DESCRIPTION
## What changed

- Removes package.json from dependency.files because the repository has no root Node project or npm lockfile.
- Adds version-scoped license declarations for four Go modules that License Eye cannot identify automatically.

## Root cause

The release workflow failed in the dependency license check for two independent reasons. License Eye attempted npm ci for the configured package.json input, but no root package.json or package-lock.json exists. It also reported four Go dependencies as Unknown because their license files were absent from the module archive or not recognized by its text matcher.

## License declarations

- github.com/xi2/xz: Unlicense classification for its explicit public-domain dedication
- github.com/fatih/color: MIT
- github.com/go-task/template: BSD-3-Clause
- github.com/olekukonko/tablewriter: MIT

These are declarations, not exclusions. License Eye continues checking compatibility for these and all other dependencies. Each override is restricted to the exact version in go.mod.

## Validation

- Passed License Eye dependency check using apache/skywalking-eyes main at commit 29bd646002b6, matching the action used by CI
- YAML syntax parsed successfully
- git diff --check passed