### PR TITLE
Restore release tests with embedded Task version fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '>=1.22.5'
-      - name: Build CLI
+      - name: Run Tests
         run: |
              ls -l
              sudo sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
              task install
              source ~/.bashrc
              ops -version
+             task tests
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/apache/openserverless-cli
 
 go 1.22.5
 
+replace github.com/sciabarracom/task/v3 => github.com/miki3421/task/v3 v3.38.12-0.20260711082633-d9ef04e0a047
+
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/a8m/envsubst v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/mattn/go-zglob v0.0.4 h1:LQi2iOm0/fGgu80AioIJ/1j9w9Oh+9DZ39J4VAGzHQM=
 github.com/mattn/go-zglob v0.0.4/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miki3421/task/v3 v3.38.12-0.20260711082633-d9ef04e0a047 h1:NcAZztL444kGBgONkThcGbQnPPmeOFz5trbr6NXiZ2k=
+github.com/miki3421/task/v3 v3.38.12-0.20260711082633-d9ef04e0a047/go.mod h1:EMjHs6YrTofApnomes/CNiGQ1odZUZF6PTqmYW9EBic=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
@@ -352,8 +354,6 @@ github.com/sciabarracom/openwhisk-wskdeploy v1.2.1 h1:t5hgca9OFEO39t4OqIxcWybYRj
 github.com/sciabarracom/openwhisk-wskdeploy v1.2.1/go.mod h1:bWjrIOIAzt8AcPqiJ0mWEecUxXbT4bY4ysMlJO6/q78=
 github.com/sciabarracom/sh/v3 v3.8.3 h1:5afHdZzNkW5vgUMP7gHUpBYHezn3BoQsyNgKXKdTpkM=
 github.com/sciabarracom/sh/v3 v3.8.3/go.mod h1:CeMVr3PRLhlUrS+VPLTp8dS5/6xNzmmX0h/WVHRR6DA=
-github.com/sciabarracom/task/v3 v3.38.11 h1:TZeaepSVc9Lx7TowAqIV3K9IZQh+jYgKNDpBNIg38uU=
-github.com/sciabarracom/task/v3 v3.38.11/go.mod h1:EMjHs6YrTofApnomes/CNiGQ1odZUZF6PTqmYW9EBic=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=


### PR DESCRIPTION
## Summary

- restore the original `task tests` command in the release workflow
- consume the Task embedded-version fix from sciabarracom/task#1
- prevent a tagged OPS version such as 0.9.1 from being interpreted as the embedded Task engine version

## Dependency and merge order

This PR is stacked on https://github.com/sciabarracom/task/pull/1 and must remain draft until that PR is merged and released. The temporary `replace` points at the exact reviewed fork commit so this PR and its tests are reproducible now. Before merging this PR, replace it with the official sciabarracom/task release tag and remove the fork replacement.

## Validation

- `go test ./internal/version` in the Task PR
- `task itest T=vars F="--formatter tap"` (5/5)
- `task itest T=prefixes F="--formatter tap"` (2/2)
- `task itest T=retry F="--formatter tap"` (3/3)
- `go test ./config ./tools ./auth`
- `git diff --check`

A local run of the root Go package reaches the existing `Example_download` network fixture and fails because the historical `olaris/0.1.0` branch cannot be cloned; this is unrelated to the embedded Task version change.