### PR TITLE
Fix build cache inputs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,8 +59,9 @@ tasks:
       - echo building {{.VERSION}}
       - go build  {{.DEBUG}} ./cmd/ops/
     sources:
-      - "*.go"
-      - "*/*.go"
+      - "**/*.go"
+      - go.mod
+      - go.sum
       - version.txt
       - branch.txt
     generates:
@@ -150,4 +151,3 @@ tasks:
               python3 difftest.py
         else  python3 difftest.py {{.N}}
         fi
-


### PR DESCRIPTION
## What changed

- Track all Go sources recursively in the `build` task.
- Include `go.mod` and `go.sum` in build cache inputs.

## Why

Dependency-only changes could leave the generated `ops` binary marked up to date, causing tests and releases to run stale code.

## Validation

- `git diff --check`
- `task --list`
- `task --force build`