### PR TITLE
Isolate test debug environment

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -130,6 +130,8 @@ tasks:
       - task: bats
       - rm -Rf ~/.ops/olaris
       - |
+        unset DEBUG
+        unset TRACE
         unset OPS_BRANCH
         unset OPS_REPO
         unset OPS_ROOT
@@ -150,4 +152,3 @@ tasks:
               python3 difftest.py
         else  python3 difftest.py {{.N}}
         fi
-


### PR DESCRIPTION
## What changed

Unset `DEBUG` and `TRACE` before running the Bats integration suite, alongside the existing OPS environment cleanup.

## Why

Any non-empty `DEBUG` or `TRACE` value enables CLI diagnostics. Those lines pollute command output captured by Bats and cause output assertions to fail depending on the caller shell.

## Validation

With the host environment still containing `DEBUG=release`:

- `task itest T=datefmt`
- `task itest T=opspath`
- `task itest T=urlenc`