### PR TITLE
Update login help expectations

### DIFF
--- a/tests/help.bats
+++ b/tests/help.bats
@@ -83,10 +83,10 @@ setup() {
 
     run ops -l
     assert_failure
-    assert_line "ops -login <apihost> [<user>]"
+    assert_line "ops -login [options] <apihost> [<user>]"
     run ops -login 
     assert_failure
-    assert_line "ops -login <apihost> [<user>]"
+    assert_line "ops -login [options] <apihost> [<user>]"
 
     run ops -c
     assert_success
@@ -96,4 +96,3 @@ setup() {
     assert_line "ops -config [options] [KEY | KEY=VALUE [KEY=VALUE ...]]"
 
 }
-

--- a/tests/login.bats
+++ b/tests/login.bats
@@ -24,12 +24,12 @@ setup() {
 @test "ops -login help" {
     run ops -login
     assert_line "Usage:"
-	assert_line "ops -login <apihost> [<user>]"
+	assert_line "ops -login [options] <apihost> [<user>]"
     assert_line "error: missing apihost"
 	
     run ops -login -h
     assert_line "Usage:"
-    assert_line "ops -login <apihost> [<user>]"
+    assert_line "ops -login [options] <apihost> [<user>]"
 }
 
 @test "ops -login with OPS_PASSWORD env does not prompt for password" {


### PR DESCRIPTION
## What changed

Update Bats assertions to match the current login usage line: `ops -login [options] <apihost> [<user>]`.

## Why

SSO login flags added an options section to the command surface, but the integration tests still asserted the pre-SSO usage string.

## Validation

- `bats login.bats` (6 tests passed)