### PR TITLE
Fix 7-Zip test downloads

### DIFF
--- a/tests/extract.bats
+++ b/tests/extract.bats
@@ -26,7 +26,7 @@ setup() {
     run ops -extract
     assert_success
     assert_line --partial "ops -extract file.(zip|tgz|tar[.gz|.bz2|.xz]) target"
-    curl -sL -o7zip.tar.xz https://www.7-zip.org/a/7z2407-linux-x64.tar.xz 
+    curl -fsSL --retry 3 -o 7zip.tar.xz https://www.7-zip.org/a/7z2301-linux-x64.tar.xz
 
     run ops -extract 7zip.tar.xz missing
     assert_failure

--- a/tests/prereq/olaris/prereq.yml
+++ b/tests/prereq/olaris/prereq.yml
@@ -66,7 +66,7 @@ tasks:
   7zz:
     desc: 7zr
     vars:
-      VERSION: "2407"
+      VERSION: "2301"
       SUFFIX:
          sh: |
              case "{{.OS}}-{{.ARCH}}" in
@@ -79,7 +79,7 @@ tasks:
       URL: "https://7-zip.org/a/{{.SUFFIX}}"
       FILE: "{{base .URL}}"
     cmds:
-    - curl -sL "{{.URL}}"  -o "{{.FILE}}"
+    - curl -fsSL --retry 3 "{{.URL}}" -o "{{.FILE}}"
     - |
       if test "{{.OS}}" == "windows" 
       then mv 7zr.exe 7zz.exe


### PR DESCRIPTION
## What changed

- Use the still-published 7-Zip 23.01 test artifacts instead of removed 24.07 URLs.
- Make curl fail on HTTP errors and retry transient failures.

## Why

The old URLs return a 404 HTML page. Tests then attempt to extract that page and fail with misleading archive errors or missing binaries.

## Validation

- `bats extract.bats`
- `bats prereq.bats`
- `bats prereq_yml.bats`

All 10 tests passed across Linux, macOS, and Windows fixture variants.