### PR TITLE
Test all Go packages

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -107,10 +107,7 @@ tasks:
     cmds:
       - rm -Rf ~/.ops
       - go clean -testcache -cache
-      - go test -count=1 {{.F}} github.com/apache/openserverless-cli
-      - go test -count=1 {{.F}} github.com/apache/openserverless-cli/config
-      - go test -count=1 {{.F}} github.com/apache/openserverless-cli/tools
-      - go test github.com/apache/openserverless-cli/auth
+      - go test -count=1 {{.F}} ./...
 
 
   bats:
@@ -150,4 +147,3 @@ tasks:
               python3 difftest.py
         else  python3 difftest.py {{.N}}
         fi
-


### PR DESCRIPTION
## What changed

Replace the manually maintained package list in `utest` with `go test -count=1 ./...`.

## Why

New packages could be omitted from CI, and the auth package did not consistently disable the Go test cache. Recursive package discovery keeps the task complete as the module evolves.

## Validation

- `task utest`

All module packages passed, including the command package discovery path.