### PR TITLE
Route SSO configuration through tasks and preserve legacy cleanup

### DIFF
--- a/config/sso_tool.go
+++ b/config/sso_tool.go
@@ -122,16 +122,12 @@ type ssoOptions struct {
 
 func printSSOUsage() {
 	fmt.Print(`Usage:
-ops config sso keycloak --enable --issuer-url URL --jwks-url URL (--audience AUDIENCE|--client-id CLIENT_ID) --required-group GROUP [options]
-ops config sso show
-ops config sso disable [options]
-
-Legacy embedded form:
 ops -config sso keycloak --enable --issuer-url URL --jwks-url URL (--audience AUDIENCE|--client-id CLIENT_ID) --required-group GROUP [options]
 ops -config sso show
 ops -config sso disable [options]
 
-Configure OpenServerless SSO/OIDC integration for admin-api.
+Legacy compatibility tool for OpenServerless SSO/OIDC integration.
+The public command surface is provided by the ops config sso task.
 
 Managed Kubernetes resources:
   ConfigMap NAME            OIDC_* and SSO_* values created by this command

--- a/config/sso_tool.go
+++ b/config/sso_tool.go
@@ -40,6 +40,62 @@ type commandRunner func(name string, args []string, stdin []byte) ([]byte, error
 
 var runSSOCommand commandRunner = realCommandRunner
 
+type ssoEnvFromSource struct {
+	Prefix       string                   `json:"prefix,omitempty"`
+	ConfigMapRef *ssoLocalObjectReference `json:"configMapRef,omitempty"`
+	SecretRef    *ssoLocalObjectReference `json:"secretRef,omitempty"`
+}
+
+type ssoLocalObjectReference struct {
+	Name     string `json:"name"`
+	Optional *bool  `json:"optional,omitempty"`
+}
+
+type ssoWorkload struct {
+	Spec struct {
+		Template struct {
+			Spec struct {
+				Containers []struct {
+					Name    string             `json:"name"`
+					EnvFrom []ssoEnvFromSource `json:"envFrom,omitempty"`
+				} `json:"containers"`
+			} `json:"spec"`
+		} `json:"template"`
+	} `json:"spec"`
+}
+
+type jsonPatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+var managedLocalSSOKeys = []string{
+	"SSO_ENABLED",
+	"SSO_PROVIDER",
+	"SSO_OIDC_ISSUER_URL",
+	"SSO_OIDC_JWKS_URL",
+	"SSO_OIDC_AUDIENCE",
+	"SSO_OIDC_CLIENT_ID",
+	"SSO_OIDC_REQUIRED_GROUP",
+	"SSO_OIDC_USERNAME_CLAIM",
+	"SSO_OIDC_GROUPS_CLAIM",
+	"SSO_OIDC_CLIENT_SECRET_CONFIGURED",
+	"SSO_CLIENT_MODE",
+	"SSO_AUTOPROVISION_ON_LOGIN",
+	"SSO_AUTOPROVISION_TIMEOUT_SECONDS",
+	"SSO_AUTOPROVISION_POLL_SECONDS",
+	"SSO_AUTOPROVISION_DEFAULT_SERVICES",
+	"SSO_NAMESPACE_PRESERVE_VALID",
+	"SSO_NAMESPACE_HASH_LENGTH",
+	"SSO_NAMESPACE_MAX_LENGTH",
+	"SSO_KUBE_NAMESPACE",
+	"SSO_KUBE_CONFIGMAP",
+	"SSO_KUBE_SECRET",
+	"SSO_KUBE_STATEFULSET",
+	"SSO_KUBE_CONTAINER",
+}
+
 type ssoOptions struct {
 	IssuerURL              string
 	JWKSURL                string
@@ -76,6 +132,14 @@ ops -config sso show
 ops -config sso disable [options]
 
 Configure OpenServerless SSO/OIDC integration for admin-api.
+
+Managed Kubernetes resources:
+  ConfigMap NAME            OIDC_* and SSO_* values created by this command
+  Secret NAME               OIDC_CLIENT_SECRET, when --client-secret is used
+  admin-api container       Exact envFrom references to those two resources
+
+The command does not manage direct env entries, other envFrom references,
+volumes, volumeMounts, or workload annotations. Disable leaves them unchanged.
 
 Options:
   --username-claim CLAIM   OIDC username claim. Default: preferred_username
@@ -133,7 +197,7 @@ func configureKeycloakSSO(configMap ConfigMap, args []string) error {
 		}
 	}
 
-	if err := patchSSOEnvFrom(opts); err != nil {
+	if _, err := reconcileSSOEnvFrom(opts, true); err != nil {
 		return err
 	}
 
@@ -310,7 +374,8 @@ func disableSSO(configMap ConfigMap, args []string) error {
 	if err := removeLocalSSOConfig(configMap); err != nil {
 		return err
 	}
-	if err := removeSSOEnvFrom(opts); err != nil {
+	workloadChanged, err := reconcileSSOEnvFrom(opts, false)
+	if err != nil {
 		return err
 	}
 	if err := deleteSSOConfigMap(opts); err != nil {
@@ -319,8 +384,8 @@ func disableSSO(configMap ConfigMap, args []string) error {
 	if err := deleteSSOSecret(opts); err != nil {
 		return err
 	}
-	if !opts.NoRollout {
-		if err := rolloutSSOWorkload(opts); err != nil {
+	if !opts.NoRollout && workloadChanged {
+		if err := waitForSSOWorkloadRollout(opts); err != nil {
 			return err
 		}
 	}
@@ -330,8 +395,9 @@ func disableSSO(configMap ConfigMap, args []string) error {
 }
 
 func removeLocalSSOConfig(configMap ConfigMap) error {
-	for key := range configMap.Flatten() {
-		if !strings.HasPrefix(key, "SSO_") {
+	values := configMap.Flatten()
+	for _, key := range managedLocalSSOKeys {
+		if _, exists := values[key]; !exists {
 			continue
 		}
 		if err := configMap.Delete(key); err != nil && !strings.Contains(err.Error(), "does not exist in config.json") {
@@ -396,64 +462,138 @@ func applySSOSecret(opts ssoOptions) error {
 	return err
 }
 
-func patchSSOEnvFrom(opts ssoOptions) error {
-	envFrom := []map[string]interface{}{
-		{
-			"configMapRef": map[string]string{
-				"name": opts.ConfigMapName,
-			},
-		},
+func reconcileSSOEnvFrom(opts ssoOptions, enabled bool) (bool, error) {
+	output, err := runSSOCommand("kubectl", []string{
+		"-n", opts.Namespace,
+		"get", "statefulset", opts.WorkloadName,
+		"-o", "json",
+	}, nil)
+	if err != nil {
+		return false, err
 	}
-	if opts.ClientSecret != "" {
-		envFrom = append(envFrom, map[string]interface{}{
-			"secretRef": map[string]string{
-				"name": opts.SecretName,
-			},
+
+	var workload ssoWorkload
+	if err := json.Unmarshal(output, &workload); err != nil {
+		return false, fmt.Errorf("decode statefulset %s/%s: %w", opts.Namespace, opts.WorkloadName, err)
+	}
+
+	containerIndex := -1
+	var current []ssoEnvFromSource
+	for index, container := range workload.Spec.Template.Spec.Containers {
+		if container.Name == opts.ContainerName {
+			containerIndex = index
+			current = container.EnvFrom
+			break
+		}
+	}
+	if containerIndex < 0 {
+		return false, fmt.Errorf("container %s not found in statefulset %s/%s", opts.ContainerName, opts.Namespace, opts.WorkloadName)
+	}
+
+	desired := make([]ssoEnvFromSource, 0, 2)
+	if enabled {
+		desired = append(desired, ssoEnvFromSource{
+			ConfigMapRef: &ssoLocalObjectReference{Name: opts.ConfigMapName},
+		})
+		if opts.ClientSecret != "" {
+			desired = append(desired, ssoEnvFromSource{
+				SecretRef: &ssoLocalObjectReference{Name: opts.SecretName},
+			})
+		}
+	}
+
+	seenDesired := make(map[string]bool)
+	removeIndexes := make([]int, 0)
+	for index, source := range current {
+		key, managed := managedSSOEnvFromKey(source, opts)
+		if !managed {
+			continue
+		}
+		if enabled && desiredSSOEnvFromKey(key, desired) && !seenDesired[key] {
+			seenDesired[key] = true
+			continue
+		}
+		removeIndexes = append(removeIndexes, index)
+	}
+
+	missing := make([]ssoEnvFromSource, 0, len(desired))
+	for _, source := range desired {
+		key, _ := managedSSOEnvFromKey(source, opts)
+		if !seenDesired[key] {
+			missing = append(missing, source)
+		}
+	}
+	if len(removeIndexes) == 0 && len(missing) == 0 {
+		return false, nil
+	}
+
+	basePath := fmt.Sprintf("/spec/template/spec/containers/%d/envFrom", containerIndex)
+	operations := make([]jsonPatchOperation, 0, len(removeIndexes)+len(missing))
+	for index := len(removeIndexes) - 1; index >= 0; index-- {
+		removeIndex := removeIndexes[index]
+		operations = append(operations, jsonPatchOperation{
+			Op:    "test",
+			Path:  fmt.Sprintf("%s/%d", basePath, removeIndex),
+			Value: current[removeIndex],
+		})
+		operations = append(operations, jsonPatchOperation{
+			Op:   "remove",
+			Path: fmt.Sprintf("%s/%d", basePath, removeIndex),
 		})
 	}
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"template": map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []map[string]interface{}{
-						{
-							"name":    opts.ContainerName,
-							"envFrom": envFrom,
-						},
-					},
-				},
-			},
-		},
+	if len(current) == 0 {
+		operations = append(operations, jsonPatchOperation{
+			Op:    "add",
+			Path:  basePath,
+			Value: missing,
+		})
+	} else {
+		for _, source := range missing {
+			operations = append(operations, jsonPatchOperation{
+				Op:    "add",
+				Path:  basePath + "/-",
+				Value: source,
+			})
+		}
 	}
-	payload, err := json.Marshal(patch)
+
+	payload, err := json.Marshal(operations)
 	if err != nil {
-		return err
+		return false, err
 	}
-	_, err = runSSOCommand("kubectl", []string{"-n", opts.Namespace, "patch", "statefulset", opts.WorkloadName, "--type=strategic", "-p", string(payload)}, nil)
-	return err
+	_, err = runSSOCommand("kubectl", []string{
+		"-n", opts.Namespace,
+		"patch", "statefulset", opts.WorkloadName,
+		"--type=json", "-p", string(payload),
+	}, nil)
+	return err == nil, err
 }
 
-func removeSSOEnvFrom(opts ssoOptions) error {
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"template": map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []map[string]interface{}{
-						{
-							"name":    opts.ContainerName,
-							"envFrom": nil,
-						},
-					},
-				},
-			},
-		},
+func managedSSOEnvFromKey(source ssoEnvFromSource, opts ssoOptions) (string, bool) {
+	if source.Prefix != "" {
+		return "", false
 	}
-	payload, err := json.Marshal(patch)
-	if err != nil {
-		return err
+	if source.ConfigMapRef != nil && source.SecretRef == nil &&
+		source.ConfigMapRef.Name == opts.ConfigMapName && source.ConfigMapRef.Optional == nil {
+		return "configmap:" + opts.ConfigMapName, true
 	}
-	_, err = runSSOCommand("kubectl", []string{"-n", opts.Namespace, "patch", "statefulset", opts.WorkloadName, "--type=strategic", "-p", string(payload)}, nil)
-	return err
+	if source.SecretRef != nil && source.ConfigMapRef == nil &&
+		source.SecretRef.Name == opts.SecretName && source.SecretRef.Optional == nil {
+		return "secret:" + opts.SecretName, true
+	}
+	return "", false
+}
+
+func desiredSSOEnvFromKey(key string, desired []ssoEnvFromSource) bool {
+	for _, source := range desired {
+		if source.ConfigMapRef != nil && key == "configmap:"+source.ConfigMapRef.Name {
+			return true
+		}
+		if source.SecretRef != nil && key == "secret:"+source.SecretRef.Name {
+			return true
+		}
+	}
+	return false
 }
 
 func deleteSSOConfigMap(opts ssoOptions) error {
@@ -470,6 +610,11 @@ func rolloutSSOWorkload(opts ssoOptions) error {
 	if _, err := runSSOCommand("kubectl", []string{"-n", opts.Namespace, "rollout", "restart", "statefulset/" + opts.WorkloadName}, nil); err != nil {
 		return err
 	}
+	_, err := runSSOCommand("kubectl", []string{"-n", opts.Namespace, "rollout", "status", "statefulset/" + opts.WorkloadName, "--timeout=180s"}, nil)
+	return err
+}
+
+func waitForSSOWorkloadRollout(opts ssoOptions) error {
 	_, err := runSSOCommand("kubectl", []string{"-n", opts.Namespace, "rollout", "status", "statefulset/" + opts.WorkloadName, "--timeout=180s"}, nil)
 	return err
 }
@@ -525,8 +670,24 @@ func realCommandRunner(name string, args []string, stdin []byte) ([]byte, error)
 		}
 		return output, fmt.Errorf("%s %s failed: %w", name, strings.Join(args, " "), err)
 	}
-	if len(output) > 0 {
+	if len(output) > 0 && !isSSOWorkloadJSONGet(name, args) {
 		fmt.Print(string(output))
 	}
 	return output, nil
+}
+
+func isSSOWorkloadJSONGet(name string, args []string) bool {
+	if name != "kubectl" {
+		return false
+	}
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == "get" && index+2 < len(args) && args[index+1] == "statefulset" {
+			for outputIndex := index + 2; outputIndex+1 < len(args); outputIndex++ {
+				if args[outputIndex] == "-o" && args[outputIndex+1] == "json" {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/config/sso_tool_test.go
+++ b/config/sso_tool_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -33,6 +34,103 @@ type recordedCommand struct {
 	stdin string
 }
 
+func ssoWorkloadJSON(envFrom ...ssoEnvFromSource) []byte {
+	workload := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{
+						{
+							"name":    defaultSSOContainer,
+							"envFrom": envFrom,
+						},
+					},
+				},
+			},
+		},
+	}
+	payload, _ := json.Marshal(workload)
+	return payload
+}
+
+func isSSOWorkloadGet(args []string) bool {
+	return len(args) >= 7 && args[2] == "get" && args[3] == "statefulset" && args[6] == "json"
+}
+
+func managedConfigMapSource() ssoEnvFromSource {
+	return ssoEnvFromSource{ConfigMapRef: &ssoLocalObjectReference{Name: defaultSSOConfigMap}}
+}
+
+func managedSecretSource() ssoEnvFromSource {
+	return ssoEnvFromSource{SecretRef: &ssoLocalObjectReference{Name: defaultSSOSecret}}
+}
+
+type fakeSSOWorkloadState struct {
+	Env          []map[string]string
+	EnvFrom      []ssoEnvFromSource
+	VolumeMounts []map[string]string
+	Volumes      []map[string]interface{}
+}
+
+func (state *fakeSSOWorkloadState) workloadJSON() []byte {
+	workload := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{
+						{
+							"name":         defaultSSOContainer,
+							"env":          state.Env,
+							"envFrom":      state.EnvFrom,
+							"volumeMounts": state.VolumeMounts,
+						},
+					},
+					"volumes": state.Volumes,
+				},
+			},
+		},
+	}
+	payload, _ := json.Marshal(workload)
+	return payload
+}
+
+func (state *fakeSSOWorkloadState) applyJSONPatch(payload string) error {
+	var operations []struct {
+		Op    string          `json:"op"`
+		Path  string          `json:"path"`
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal([]byte(payload), &operations); err != nil {
+		return err
+	}
+	for _, operation := range operations {
+		switch operation.Op {
+		case "remove":
+			parts := strings.Split(operation.Path, "/")
+			index, err := strconv.Atoi(parts[len(parts)-1])
+			if err != nil {
+				return err
+			}
+			state.EnvFrom = append(state.EnvFrom[:index], state.EnvFrom[index+1:]...)
+		case "add":
+			if strings.HasSuffix(operation.Path, "/-") {
+				var source ssoEnvFromSource
+				if err := json.Unmarshal(operation.Value, &source); err != nil {
+					return err
+				}
+				state.EnvFrom = append(state.EnvFrom, source)
+				continue
+			}
+			var sources []ssoEnvFromSource
+			if err := json.Unmarshal(operation.Value, &sources); err != nil {
+				return err
+			}
+			state.EnvFrom = sources
+		}
+	}
+	return nil
+}
+
 func TestConfigSSOToolKeycloak(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.json")
@@ -43,6 +141,9 @@ func TestConfigSSOToolKeycloak(t *testing.T) {
 	oldRunner := runSSOCommand
 	runSSOCommand = func(name string, args []string, stdin []byte) ([]byte, error) {
 		commands = append(commands, recordedCommand{name: name, args: args, stdin: string(stdin)})
+		if isSSOWorkloadGet(args) {
+			return ssoWorkloadJSON(), nil
+		}
 		return []byte("ok"), nil
 	}
 	defer func() { runSSOCommand = oldRunner }()
@@ -65,9 +166,10 @@ func TestConfigSSOToolKeycloak(t *testing.T) {
 	require.Equal(t, true, gotConfig["sso"].(map[string]interface{})["autoprovision"].(map[string]interface{})["on"].(map[string]interface{})["login"])
 	require.Equal(t, float64(120), gotConfig["sso"].(map[string]interface{})["autoprovision"].(map[string]interface{})["timeout"].(map[string]interface{})["seconds"])
 
-	require.Len(t, commands, 2)
+	require.Len(t, commands, 3)
 	require.Equal(t, []string{"apply", "-f", "-"}, commands[0].args)
-	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=strategic", "-p", commands[1].args[7]}, commands[1].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "get", "statefulset", "nuvolaris-system-api", "-o", "json"}, commands[1].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=json", "-p", commands[2].args[7]}, commands[2].args)
 
 	var cmObj map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(commands[0].stdin), &cmObj))
@@ -96,6 +198,9 @@ func TestConfigSSOToolKeycloakRollsOutAdminAPIByDefault(t *testing.T) {
 	oldRunner := runSSOCommand
 	runSSOCommand = func(name string, args []string, stdin []byte) ([]byte, error) {
 		commands = append(commands, recordedCommand{name: name, args: args, stdin: string(stdin)})
+		if isSSOWorkloadGet(args) {
+			return ssoWorkloadJSON(), nil
+		}
 		return []byte("ok"), nil
 	}
 	defer func() { runSSOCommand = oldRunner }()
@@ -110,11 +215,12 @@ func TestConfigSSOToolKeycloakRollsOutAdminAPIByDefault(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Len(t, commands, 4)
+	require.Len(t, commands, 5)
 	require.Equal(t, []string{"apply", "-f", "-"}, commands[0].args)
-	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=strategic", "-p", commands[1].args[7]}, commands[1].args)
-	require.Equal(t, []string{"-n", "nuvolaris", "rollout", "restart", "statefulset/nuvolaris-system-api"}, commands[2].args)
-	require.Equal(t, []string{"-n", "nuvolaris", "rollout", "status", "statefulset/nuvolaris-system-api", "--timeout=180s"}, commands[3].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "get", "statefulset", "nuvolaris-system-api", "-o", "json"}, commands[1].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=json", "-p", commands[2].args[7]}, commands[2].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "rollout", "restart", "statefulset/nuvolaris-system-api"}, commands[3].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "rollout", "status", "statefulset/nuvolaris-system-api", "--timeout=180s"}, commands[4].args)
 }
 
 func TestConfigSSOToolKeycloakWithClientSecret(t *testing.T) {
@@ -127,6 +233,9 @@ func TestConfigSSOToolKeycloakWithClientSecret(t *testing.T) {
 	oldRunner := runSSOCommand
 	runSSOCommand = func(name string, args []string, stdin []byte) ([]byte, error) {
 		commands = append(commands, recordedCommand{name: name, args: args, stdin: string(stdin)})
+		if isSSOWorkloadGet(args) {
+			return ssoWorkloadJSON(), nil
+		}
 		return []byte("ok"), nil
 	}
 	defer func() { runSSOCommand = oldRunner }()
@@ -155,7 +264,7 @@ func TestConfigSSOToolKeycloakWithClientSecret(t *testing.T) {
 	require.Equal(t, "true", flat["SSO_OIDC_CLIENT_SECRET_CONFIGURED"])
 	require.Equal(t, "custom-sso-secret", flat["SSO_KUBE_SECRET"])
 
-	require.Len(t, commands, 3)
+	require.Len(t, commands, 4)
 
 	var cmObj map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(commands[0].stdin), &cmObj))
@@ -172,8 +281,9 @@ func TestConfigSSOToolKeycloakWithClientSecret(t *testing.T) {
 	secretData := secretObj["stringData"].(map[string]interface{})
 	require.Equal(t, "super-secret", secretData["OIDC_CLIENT_SECRET"])
 
-	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=strategic", "-p", commands[2].args[7]}, commands[2].args)
-	require.Contains(t, commands[2].args[7], "custom-sso-secret")
+	require.Equal(t, []string{"-n", "nuvolaris", "get", "statefulset", "nuvolaris-system-api", "-o", "json"}, commands[2].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=json", "-p", commands[3].args[7]}, commands[3].args)
+	require.Contains(t, commands[3].args[7], "custom-sso-secret")
 }
 
 func TestConfigSSOToolKeycloakRequiresValues(t *testing.T) {
@@ -196,7 +306,8 @@ func TestConfigSSOToolDisable(t *testing.T) {
       "issuer": {
         "url": "http://issuer"
       }
-    }
+    },
+    "external": "preserve-me"
   }
 }`), 0644))
 
@@ -207,6 +318,9 @@ func TestConfigSSOToolDisable(t *testing.T) {
 	oldRunner := runSSOCommand
 	runSSOCommand = func(name string, args []string, stdin []byte) ([]byte, error) {
 		commands = append(commands, recordedCommand{name: name, args: args, stdin: string(stdin)})
+		if isSSOWorkloadGet(args) {
+			return ssoWorkloadJSON(managedConfigMapSource(), managedSecretSource()), nil
+		}
 		return []byte("ok"), nil
 	}
 	defer func() { runSSOCommand = oldRunner }()
@@ -216,13 +330,19 @@ func TestConfigSSOToolDisable(t *testing.T) {
 
 	gotConfig, err := readConfig(configPath, fromConfigJson)
 	require.NoError(t, err)
-	require.Empty(t, gotConfig)
-	require.Len(t, commands, 3)
-	require.Equal(t, []string{"-n", "nuvolaris", "delete", "configmap", "openserverless-sso-config", "--ignore-not-found"}, commands[1].args)
-	require.Equal(t, []string{"-n", "nuvolaris", "delete", "secret", "openserverless-sso-secret", "--ignore-not-found"}, commands[2].args)
+	require.Equal(t, map[string]interface{}{
+		"sso": map[string]interface{}{
+			"external": "preserve-me",
+		},
+	}, gotConfig)
+	require.Len(t, commands, 4)
+	require.Equal(t, []string{"-n", "nuvolaris", "get", "statefulset", "nuvolaris-system-api", "-o", "json"}, commands[0].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=json", "-p", commands[1].args[7]}, commands[1].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "delete", "configmap", "openserverless-sso-config", "--ignore-not-found"}, commands[2].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "delete", "secret", "openserverless-sso-secret", "--ignore-not-found"}, commands[3].args)
 }
 
-func TestConfigSSOToolDisableRollsOutAdminAPIByDefault(t *testing.T) {
+func TestConfigSSOToolDisableWaitsForAdminAPIRolloutByDefault(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.json")
 	cm, err := NewConfigMapBuilder().WithConfigJson(configPath).Build()
@@ -232,6 +352,9 @@ func TestConfigSSOToolDisableRollsOutAdminAPIByDefault(t *testing.T) {
 	oldRunner := runSSOCommand
 	runSSOCommand = func(name string, args []string, stdin []byte) ([]byte, error) {
 		commands = append(commands, recordedCommand{name: name, args: args, stdin: string(stdin)})
+		if isSSOWorkloadGet(args) {
+			return ssoWorkloadJSON(managedConfigMapSource(), managedSecretSource()), nil
+		}
 		return []byte("ok"), nil
 	}
 	defer func() { runSSOCommand = oldRunner }()
@@ -240,9 +363,141 @@ func TestConfigSSOToolDisableRollsOutAdminAPIByDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, commands, 5)
-	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=strategic", "-p", commands[0].args[7]}, commands[0].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "get", "statefulset", "nuvolaris-system-api", "-o", "json"}, commands[0].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "patch", "statefulset", "nuvolaris-system-api", "--type=json", "-p", commands[1].args[7]}, commands[1].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "delete", "configmap", "openserverless-sso-config", "--ignore-not-found"}, commands[2].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "delete", "secret", "openserverless-sso-secret", "--ignore-not-found"}, commands[3].args)
+	require.Equal(t, []string{"-n", "nuvolaris", "rollout", "status", "statefulset/nuvolaris-system-api", "--timeout=180s"}, commands[4].args)
+}
+
+func TestConfigSSOToolDisableAlreadyAbsentDoesNotPatchOrRollOut(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	cm, err := NewConfigMapBuilder().WithConfigJson(configPath).Build()
+	require.NoError(t, err)
+
+	foreign := ssoEnvFromSource{
+		ConfigMapRef: &ssoLocalObjectReference{Name: "application-config"},
+	}
+	var commands []recordedCommand
+	oldRunner := runSSOCommand
+	runSSOCommand = func(name string, args []string, stdin []byte) ([]byte, error) {
+		commands = append(commands, recordedCommand{name: name, args: args, stdin: string(stdin)})
+		if isSSOWorkloadGet(args) {
+			return ssoWorkloadJSON(foreign), nil
+		}
+		return []byte("ok"), nil
+	}
+	defer func() { runSSOCommand = oldRunner }()
+
+	require.NoError(t, ConfigSSOTool(cm, []string{"disable"}))
+	require.Len(t, commands, 3)
+	require.Equal(t, []string{"-n", "nuvolaris", "get", "statefulset", "nuvolaris-system-api", "-o", "json"}, commands[0].args)
 	require.Equal(t, []string{"-n", "nuvolaris", "delete", "configmap", "openserverless-sso-config", "--ignore-not-found"}, commands[1].args)
 	require.Equal(t, []string{"-n", "nuvolaris", "delete", "secret", "openserverless-sso-secret", "--ignore-not-found"}, commands[2].args)
-	require.Equal(t, []string{"-n", "nuvolaris", "rollout", "restart", "statefulset/nuvolaris-system-api"}, commands[3].args)
-	require.Equal(t, []string{"-n", "nuvolaris", "rollout", "status", "statefulset/nuvolaris-system-api", "--timeout=180s"}, commands[4].args)
+}
+
+func TestConfigSSOToolPreservesForeignWorkloadFieldsAcrossEnableDisableEnable(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	cm, err := NewConfigMapBuilder().WithConfigJson(configPath).Build()
+	require.NoError(t, err)
+
+	state := fakeSSOWorkloadState{
+		Env: []map[string]string{
+			{"name": "APPLICATION_MODE", "value": "production"},
+		},
+		EnvFrom: []ssoEnvFromSource{
+			{ConfigMapRef: &ssoLocalObjectReference{Name: "application-config"}},
+			{SecretRef: &ssoLocalObjectReference{Name: "database-credentials"}},
+		},
+		VolumeMounts: []map[string]string{
+			{"name": "application-data", "mountPath": "/data"},
+		},
+		Volumes: []map[string]interface{}{
+			{"name": "application-data", "emptyDir": map[string]interface{}{}},
+		},
+	}
+	originalEnv, err := json.Marshal(state.Env)
+	require.NoError(t, err)
+	originalMounts, err := json.Marshal(state.VolumeMounts)
+	require.NoError(t, err)
+	originalVolumes, err := json.Marshal(state.Volumes)
+	require.NoError(t, err)
+
+	var commands []recordedCommand
+	var patchPayloads []string
+	oldRunner := runSSOCommand
+	runSSOCommand = func(name string, args []string, stdin []byte) ([]byte, error) {
+		commands = append(commands, recordedCommand{name: name, args: args, stdin: string(stdin)})
+		if isSSOWorkloadGet(args) {
+			return state.workloadJSON(), nil
+		}
+		if len(args) >= 8 && args[2] == "patch" && args[5] == "--type=json" {
+			patchPayloads = append(patchPayloads, args[7])
+			if err := state.applyJSONPatch(args[7]); err != nil {
+				return nil, err
+			}
+		}
+		return []byte("ok"), nil
+	}
+	defer func() { runSSOCommand = oldRunner }()
+
+	enableArgs := []string{
+		"keycloak",
+		"--enable",
+		"--issuer-url", "https://keycloak.example.test/realms/openserverless",
+		"--jwks-url", "https://keycloak.example.test/realms/openserverless/protocol/openid-connect/certs",
+		"--client-id", "openserverless-admin-api",
+		"--client-secret", "test-secret",
+		"--required-group", "openserverless-users",
+		"--no-rollout",
+	}
+	require.NoError(t, ConfigSSOTool(cm, enableArgs))
+	require.Equal(t, []ssoEnvFromSource{
+		{ConfigMapRef: &ssoLocalObjectReference{Name: "application-config"}},
+		{SecretRef: &ssoLocalObjectReference{Name: "database-credentials"}},
+		managedConfigMapSource(),
+		managedSecretSource(),
+	}, state.EnvFrom)
+
+	require.NoError(t, ConfigSSOTool(cm, []string{"disable", "--no-rollout"}))
+	require.Equal(t, []ssoEnvFromSource{
+		{ConfigMapRef: &ssoLocalObjectReference{Name: "application-config"}},
+		{SecretRef: &ssoLocalObjectReference{Name: "database-credentials"}},
+	}, state.EnvFrom)
+	require.Len(t, patchPayloads, 2)
+	require.JSONEq(t, `[
+  {"op":"test","path":"/spec/template/spec/containers/0/envFrom/3","value":{"secretRef":{"name":"openserverless-sso-secret"}}},
+  {"op":"remove","path":"/spec/template/spec/containers/0/envFrom/3"},
+  {"op":"test","path":"/spec/template/spec/containers/0/envFrom/2","value":{"configMapRef":{"name":"openserverless-sso-config"}}},
+  {"op":"remove","path":"/spec/template/spec/containers/0/envFrom/2"}
+]`, patchPayloads[1])
+
+	// Repeating disable is idempotent: resources are deleted with
+	// --ignore-not-found and no StatefulSet patch or rollout is produced.
+	require.NoError(t, ConfigSSOTool(cm, []string{"disable", "--no-rollout"}))
+	require.Len(t, patchPayloads, 2)
+
+	require.NoError(t, ConfigSSOTool(cm, enableArgs))
+	require.Equal(t, []ssoEnvFromSource{
+		{ConfigMapRef: &ssoLocalObjectReference{Name: "application-config"}},
+		{SecretRef: &ssoLocalObjectReference{Name: "database-credentials"}},
+		managedConfigMapSource(),
+		managedSecretSource(),
+	}, state.EnvFrom)
+	require.Len(t, patchPayloads, 3)
+
+	currentEnv, err := json.Marshal(state.Env)
+	require.NoError(t, err)
+	currentMounts, err := json.Marshal(state.VolumeMounts)
+	require.NoError(t, err)
+	currentVolumes, err := json.Marshal(state.Volumes)
+	require.NoError(t, err)
+	require.JSONEq(t, string(originalEnv), string(currentEnv))
+	require.JSONEq(t, string(originalMounts), string(currentMounts))
+	require.JSONEq(t, string(originalVolumes), string(currentVolumes))
+	for _, command := range commands {
+		require.NotContains(t, command.args, "rollout")
+	}
 }

--- a/docs/SSO.md
+++ b/docs/SSO.md
@@ -1,0 +1,70 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+# SSO configuration ownership
+
+`ops config sso keycloak --enable` manages the following configuration. The
+resource names can be changed with `--configmap`, `--secret`, `--statefulset`,
+and `--container`.
+
+## Kubernetes resources
+
+The command creates and owns a dedicated ConfigMap. Its default name is
+`openserverless-sso-config`, and it contains exactly these keys:
+
+- `OIDC_ISSUER_URL`
+- `OIDC_JWKS_URL`
+- `OIDC_AUDIENCE`
+- `OIDC_CLIENT_ID`
+- `OIDC_REQUIRED_GROUP`
+- `OIDC_USERNAME_CLAIM`
+- `OIDC_GROUPS_CLAIM`
+- `SSO_AUTOPROVISION_ON_LOGIN`
+- `SSO_AUTOPROVISION_TIMEOUT_SECONDS`
+- `SSO_AUTOPROVISION_POLL_SECONDS`
+- `SSO_AUTOPROVISION_DEFAULT_SERVICES`
+- `SSO_NAMESPACE_PRESERVE_VALID`
+- `SSO_NAMESPACE_HASH_LENGTH`
+- `SSO_NAMESPACE_MAX_LENGTH`
+
+When `--client-secret` is supplied, the command also creates and owns a
+dedicated Secret. Its default name is `openserverless-sso-secret`, and its only
+managed key is `OIDC_CLIENT_SECRET`.
+
+The command adds exact, prefix-free `envFrom` references for the managed
+ConfigMap and, when applicable, the managed Secret to the selected admin-api
+container. It does not create direct `env` entries, volumes, volume mounts, or
+annotations.
+
+## Disable behavior
+
+`ops config sso disable` removes only the exact `envFrom` references described
+above and deletes the two dedicated resources with Kubernetes
+`--ignore-not-found`. Other `envFrom` entries, all direct `env` entries,
+volumes, volume mounts, and existing annotations remain unchanged.
+
+The command is idempotent. If neither managed reference is present, no patch or
+rollout command is issued for the StatefulSet. Missing ConfigMaps and Secrets
+are not errors. Removing an `envFrom` entry changes the pod template, so
+Kubernetes starts the necessary rollout itself. By default the command waits
+for that rollout; `--no-rollout` skips the wait and does not issue an additional
+restart.
+
+The local `~/.ops/config.json` cleanup is also limited to the keys written by
+the SSO command. Unrecognized `SSO_*` keys are preserved.

--- a/docs/SSO.md
+++ b/docs/SSO.md
@@ -17,11 +17,13 @@
   ~ under the License.
   -->
 
-# SSO configuration ownership
+# Legacy embedded SSO configuration ownership
 
-`ops config sso keycloak --enable` manages the following configuration. The
-resource names can be changed with `--configmap`, `--secret`, `--statefulset`,
-and `--container`.
+The public `ops config sso` command is supplied by the task repository. The
+embedded `ops -config sso` form remains temporarily available for compatibility
+with already published scripts and installations. It manages the following
+configuration. Resource names can be changed with `--configmap`, `--secret`,
+`--statefulset`, and `--container`.
 
 ## Kubernetes resources
 

--- a/main.go
+++ b/main.go
@@ -408,14 +408,6 @@ func Main() {
 
 	args := os.Args
 
-	// Keep the historical `ops config` task surface intact; only the new SSO
-	// subtree is handled by the embedded config tool.
-	if isPlainConfigSSOCommand(args) {
-		fullargs := append([]string{"config"}, args[2:]...)
-		exitCode := executeTools(fullargs, opsHome)
-		os.Exit(exitCode)
-	}
-
 	// first argument with prefix "-" is considered an embedded tool
 	// using "-" or "--" or "-task" invokes the embedded task
 	// CLI: ops -<tool> (embedded tool)
@@ -552,10 +544,6 @@ func wskNamespaceSet(namespace string) error {
 
 func isPlainEmbeddedToolAlias(name string) bool {
 	return false
-}
-
-func isPlainConfigSSOCommand(args []string) bool {
-	return len(args) > 2 && args[1] == "config" && args[2] == "sso"
 }
 
 func runOps(baseDir string, args []string) error {

--- a/main_test.go
+++ b/main_test.go
@@ -156,14 +156,6 @@ func TestPlainEmbeddedToolAlias(t *testing.T) {
 	require.False(t, isPlainEmbeddedToolAlias("login"))
 }
 
-func TestIsPlainConfigSSOCommand(t *testing.T) {
-	require.True(t, isPlainConfigSSOCommand([]string{"ops", "config", "sso"}))
-	require.True(t, isPlainConfigSSOCommand([]string{"ops", "config", "sso", "show"}))
-	require.False(t, isPlainConfigSSOCommand([]string{"ops", "config"}))
-	require.False(t, isPlainConfigSSOCommand([]string{"ops", "config", "--help"}))
-	require.False(t, isPlainConfigSSOCommand([]string{"ops", "-config", "sso"}))
-}
-
 func TestConfigValueForDebugRedactsSensitiveValues(t *testing.T) {
 	require.Equal(t, "<redacted>", configValueForDebug("AUTH", "uuid:key"))
 	require.Equal(t, "<redacted>", configValueForDebug("POSTGRES_PASSWORD", "secret"))


### PR DESCRIPTION
## Summary

- replace the destructive strategic merge patch used by `ops config sso disable` with targeted JSON Patch operations
- preserve unrelated `env`, `envFrom`, volumes, volume mounts, and annotations on the admin-api StatefulSet
- make disable idempotent and avoid an unnecessary explicit rollout restart
- preserve unrecognized local `SSO_*` configuration keys
- restore the standard task dispatcher for the public `ops config sso` command
- retain the safe embedded `ops -config sso` implementation only as a documented legacy compatibility surface
- document the exact Kubernetes resources and values owned by the legacy helper

## Root cause

The previous disable implementation sent `envFrom: null` for the selected admin-api container. Kubernetes therefore removed the complete `envFrom` list, including ConfigMap and Secret references installed by other components. The enable path also replaced the complete list.

In addition, `main.go` intercepted `ops config sso` before normal task dispatch. This made SSO the only `ops config` subtree whose release-specific orchestration lived in the CLI and required a new CLI release for every change.

The new implementation reads the StatefulSet and adds or removes only exact, prefix-free references to the ConfigMap and Secret managed by `ops config sso`. JSON Patch `test` operations guard removals so a concurrent list change cannot make the command remove the wrong entry.

The special public dispatcher is removed. A companion pull request in `apache/openserverless-task` supplies the real `config/sso` task on branch `0.9.1`. The embedded form remains available only through `ops -config sso` for backward compatibility.

## Behavior

- missing managed ConfigMaps and Secrets remain non-errors through `--ignore-not-found`
- a repeated disable does not patch or roll out the StatefulSet
- `--no-rollout` skips rollout waiting and does not issue a restart
- the pod-template change caused by removing `envFrom` references starts the required Kubernetes rollout without adding a redundant restart annotation

## Validation

- `go test -count=1 ./...`
- `go test -race ./config`
- `go vet ./config`
- `go build ./cmd/ops`
- `git diff --check`
- Linux arm64 Lima/Kind: original `testing/tests/11-sso-mock.sh kind` with companion task PR (`rc=0`)

Tests cover unrelated direct environment variables, unrelated ConfigMap and Secret `envFrom` references, unrelated volumes and mounts, repeated disable, and the complete `enable -> disable -> enable` cycle.
