### PR TITLE
Document 0.9.0 SSO prerequisites and add missing ASF header

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This is the `ops` cli, the starting point to install and manage Apache OpenServe
 
 Check [the installation instructions](https://openserverless.apache.org/docs/installation/install-cli/)
 
+For `ops config sso`, see [SSO command ownership and 0.9.0 prerequisites](docs/SSO.md).
+
 
 **NOTE** in windows there are some features like the ide that requires you use a devcontainer
 with `ops ide devcontainer`

--- a/docs/SSO.md
+++ b/docs/SSO.md
@@ -17,13 +17,108 @@
   ~ under the License.
   -->
 
-# Legacy embedded SSO configuration ownership
+# SSO command ownership and 0.9.0 prerequisites
 
-The public `ops config sso` command is supplied by the task repository. The
-embedded `ops -config sso` form remains temporarily available for compatibility
-with already published scripts and installations. It manages the following
-configuration. Resource names can be changed with `--configmap`, `--secret`,
-`--statefulset`, and `--container`.
+The public `ops config sso` command requires SSO tasks from
+`apache/openserverless-task` and an OIDC-capable `apache/openserverless-admin-api`.
+At the branch snapshots below, those components are missing from `0.9.0`, even
+though the CLI already contains the SSO configuration and login code from
+`0.9.1`. Updating the CLI alone does not enable SSO on a `0.9.0` installation.
+
+## Command ownership
+
+| Command | Implementation | Responsibility |
+| --- | --- | --- |
+| `ops config sso ...` | Task repository: `config/sso/docopts.md`, `config/sso/opsfile.yml`, `config/sso/sso.ts` | Public configuration command, executed with Bun and kubectl. |
+| `ops -config sso ...` | CLI: [config/config_tool.go](../config/config_tool.go), [config/sso_tool.go](../config/sso_tool.go) | Legacy embedded configuration tool. |
+| `ops -login ...` | CLI: [auth/login.go](../auth/login.go) | SSO device and password login through admin-api, alongside legacy login. |
+| `ops ide login ...` | Task repository: `ide/opsfile.yml` | Workspace setup and delegation to the embedded login tool. |
+
+The CLI routes `ops config sso` through its normal task lookup. It does not
+fall back to the embedded configuration tool when the SSO task is missing.
+The embedded form remains temporarily available for compatibility with
+already published scripts and installations; it still requires an
+OIDC-capable admin-api for SSO login to work.
+
+## Branch comparison
+
+Checked on 2026-09-10. The links pin the reviewed commits because branch heads
+can change independently across repositories.
+
+| Repository | `0.9.0` snapshot | `0.9.1` snapshot | SSO status in `0.9.0` |
+| --- | --- | --- | --- |
+| `apache/openserverless-cli` | [83075cbc](https://github.com/apache/openserverless-cli/tree/83075cbc890dd9692782e27340fd2eee6b498a59) | [a0dd56cf](https://github.com/apache/openserverless-cli/tree/a0dd56cf5667acb092cfbac14de531f5de139af0) | `config/` and `auth/`, including their tests, are identical to `0.9.1`. No SSO code backport is needed in the CLI. |
+| `apache/openserverless-task` | [eeac57e4](https://github.com/apache/openserverless-task/tree/eeac57e4179381ee18fba290ab79d6cec1dafb09) | [71bd01f6](https://github.com/apache/openserverless-task/tree/71bd01f649d4f6b551240b7a3fa1db47954f4c6b) | Missing `config/sso/`, SSO help discovery, `admin/sso/`, and SSO changes to IDE login and user lifecycle tasks. |
+| `apache/openserverless-admin-api` | [161c479f](https://github.com/apache/openserverless-admin-api/tree/161c479f318f932e58eced08acd0830e7e75b288) | [35f9a1bc](https://github.com/apache/openserverless-admin-api/tree/35f9a1bcac5f75aab6dfac07d7efa6ac1bd0ae56) | Missing the OIDC bridge, device/password endpoints, SSO namespace mapping and login-triggered provisioning. |
+| `apache/openserverless-testing` | [be7b3338](https://github.com/apache/openserverless-testing/tree/be7b33382e02c6543d3e8813724b0177fae1c18d) | [e017ff5f](https://github.com/apache/openserverless-testing/tree/e017ff5fb5b1147cdb772aa584223d6e0d6c83da) | Missing `tests/11-sso-mock.sh` and `tests/mock-oidc-provider.py`. |
+
+The external components to review for a separate backport are:
+
+- **Configuration tasks:** `config/sso/` (including `sso.test.ts`) and the SSO
+  entries in `config/docopts.md`. The task uses Bun and kubectl from the task
+  prerequisites.
+- **Login and lifecycle tasks:** SSO handling in `ide/opsfile.yml`,
+  `ide/docopts.md`, `admin/opsfile.yml`, `admin/docopts.md`, `admin/sso/`, and
+  SSO display columns in `setup/kubernetes/crds/whisk-user-crd.yaml`.
+- **Admin-api:** `openserverless/common/oidc_validator.py`,
+  `openserverless/common/sso_namespace.py`,
+  `openserverless/impl/auth/oidc_device_flow_service.py`, the SSO additions in
+  `openserverless/impl/auth/auth_service.py` and `openserverless/rest/auth.py`,
+  their dependencies, configuration documentation and tests. These supply
+  `/auth/oidc`, `/auth/oidc/device/start`,
+  `/auth/oidc/device/poll`, and `/auth/oidc/password`, all under
+  `/system/api/v1`.
+- **Integration tests:** the mock provider and SSO smoke script in the testing
+  repository. They complement the CLI unit tests with a deployed admin-api
+  and Kubernetes resources.
+
+Setting local `SSO_*` values or creating a ConfigMap cannot add the missing
+server endpoints. A coordinated task/admin-api backport and integration
+validation are required before the public SSO flow can be considered usable
+with `0.9.0`.
+
+With the `0.9.0` task snapshot above, `ops config sso --help` and
+`ops config sso show` exit with `no command named sso found`.
+`ops -config sso --help` still succeeds because that command is embedded in
+the CLI. The same CLI can resolve `ops config sso --help` with the `0.9.1`
+tasks; this verifies command discovery, not server-side SSO compatibility.
+
+## Kubernetes compatibility
+
+The `0.9.0` deployment manifests and the SSO defaults use different names:
+
+| Resource | `0.9.0` deployment | Embedded SSO / `0.9.1` deployment |
+| --- | --- | --- |
+| Namespace | `openserverless` | `nuvolaris` |
+| Admin-api StatefulSet and container | `openserverless-system-api` | `nuvolaris-system-api` |
+| `WhiskUser` API version | `openserverless.org/v1` | `nuvolaris.org/v1` in the `0.9.1` admin-api/operator |
+
+See the task repository's
+[0.9.0 admin-api template](https://github.com/apache/openserverless-task/blob/eeac57e4179381ee18fba290ab79d6cec1dafb09/setup/openserverless/system-api/api-template.yaml)
+and the operator's
+[0.9.0 WhiskUser CRD](https://github.com/apache/openserverless-operator/blob/5df76feda569b374276f4e2c72a46d3a980a4b77/deploy/openserverless-permissions/whisk-user-crd.yaml).
+The corresponding
+[0.9.1 CRD](https://github.com/apache/openserverless-operator/blob/fdcbbdf2332ae5aa8e22afba0704b37fdb1697bd/deploy/nuvolaris-permissions/whisk-user-crd.yaml)
+uses `nuvolaris.org`.
+
+`--namespace`, `--statefulset`, and `--container` select the resources patched
+by the configuration command. They do not change the namespace or API group
+used internally by the
+[0.9.1 admin-api provisioning code](https://github.com/apache/openserverless-admin-api/blob/35f9a1bcac5f75aab6dfac07d7efa6ac1bd0ae56/openserverless/impl/auth/auth_service.py)
+and its
+[Kubernetes client](https://github.com/apache/openserverless-admin-api/blob/35f9a1bcac5f75aab6dfac07d7efa6ac1bd0ae56/openserverless/common/kube_api_client.py).
+A future backport must align those values with the deployed operator and CRD;
+copying the `0.9.1` image or tasks without adaptation is insufficient.
+
+The external-IdP flow uses the operator's existing `WhiskUser` reconciliation.
+Configuring SSO does not install Keycloak or add a Keycloak reconciler to the
+operator. An external Keycloak/IdP must already be available.
+
+## Legacy embedded configuration ownership
+
+`ops -config sso` manages the configuration described below. Resource names
+can be changed with `--namespace`, `--configmap`, `--secret`, `--statefulset`,
+and `--container`.
 
 ## Kubernetes resources
 
@@ -56,7 +151,7 @@ annotations.
 
 ## Disable behavior
 
-`ops config sso disable` removes only the exact `envFrom` references described
+`ops -config sso disable` removes only the exact `envFrom` references described
 above and deletes the two dedicated resources with Kubernetes
 `--ignore-not-found`. Other `envFrom` entries, all direct `env` entries,
 volumes, volume mounts, and existing annotations remain unchanged.

--- a/tests/test_helper/fail_then_succeed.sh
+++ b/tests/test_helper/fail_then_succeed.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 file_path=".test_fail_then_succeed"
 


### PR DESCRIPTION
`ops config sso` fails with `no command named sso found` when the CLI uses the current `0.9.0` task repository. The CLI's `auth/` and `config/` trees already match the compared `0.9.1` revision; the missing implementation belongs to the task and admin-api repositories.

This draft documents the coordinated SSO backport, pins the compared revisions, explains the `openserverless` versus `nuvolaris` namespace/workload/CRD differences, and corrects the legacy disable example to `ops -config sso disable`. It also adds the missing ASF header to `tests/test_helper/fail_then_succeed.sh`, identified during the 0.9.0 RC source audit. The shell body, shebang and executable mode are unchanged.

The header was generated with the top-level `task license CMD=fix` in an isolated copy using a temporary configuration selecting the six audited files across CLI, runtimes and testing. Only the generated header is added here; the repository's license configuration is unchanged.

### Validation

- Targeted top-level `task license CMD=check`: all six audited files valid, zero invalid; the CLI helper is included explicitly.
- Repository `license-eye header check`: 133 valid, zero invalid, 76 ignored.
- Exact byte comparison after removing the generated header, preserved file mode, `bash -n`, and `git diff --check` passed.
- Prior validation at `7b4283694b798da6163d11f97170eff93e505e47`: Go 1.24.3 auth/config tests and CLI build passed. The compared auth/config trees were identical, and five isolated CLI command-discovery checks passed.
- That same pre-header CLI revision was subsequently built and tested with the companion backports in a KVM guest using Keycloak 26.4.2 over HTTP: 32/32 checks passed, including password/device login, operator provisioning, action invocation, negative authentication cases and SSO enable/disable. These functional tests preceded this comment-only addition.

### Companion drafts

- [admin-api PR](https://github.com/apache/openserverless-admin-api/pull/53)
- [task PR](https://github.com/apache/openserverless-task/pull/230)
- [testing PR](https://github.com/apache/openserverless-testing/pull/14)

Supersedes https://github.com/apache/openserverless-cli/pull/52 with the same commits proposed from a personal fork. The previous Apache branch is retained.
